### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
+  - "node"
+  - "10"
   - "8"


### PR DESCRIPTION
We should test the build on all current LTS and stable (`node`) releases to catch any issues arising on Node.js > 8.