### PR TITLE
Add vim motions to box.key (j/k/h/l)

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -163,8 +163,8 @@ Next commands available in interactive mode:
 | `q` or `Esc` or `Ctrl`+`c`    | Exit                    |
 | `e`/`E`                       | Expand/Collapse all     |
 | `g`/`G`                       | Goto top/bottom         |
-| `up`/`down`                   | Move cursor up/down     |
-| `left`/`right`                | Expand/Collapse         |
+| `up`/`down` or `k/j`          | Move cursor up/down     |
+| `left`/`right` or `h/l`       | Expand/Collapse         |
 | `.`                           | Edit filter             |
 
 These commands are available when editing the filter:

--- a/fx.js
+++ b/fx.js
@@ -164,7 +164,7 @@ module.exports = function start(filename, source) {
     render()
   })
 
-  box.key('up', function () {
+  box.key(['up', 'k'], function () {
     program.showCursor()
 
     const [n] = getLine(program.y)
@@ -184,7 +184,7 @@ module.exports = function start(filename, source) {
     }
   })
 
-  box.key('down', function () {
+  box.key(['down', 'j'], function () {
     program.showCursor()
 
     const [n] = getLine(program.y)
@@ -204,7 +204,7 @@ module.exports = function start(filename, source) {
     }
   })
 
-  box.key('right', function () {
+  box.key(['right', 'l'], function () {
     const [n, line] = getLine(program.y)
     program.showCursor()
     program.cursorPos(program.y, line.search(/\S/))
@@ -215,7 +215,7 @@ module.exports = function start(filename, source) {
     }
   })
 
-  box.key('left', function () {
+  box.key(['left', 'h'], function () {
     const [n, line] = getLine(program.y)
     program.showCursor()
     program.cursorPos(program.y, line.search(/\S/))


### PR DESCRIPTION
Thanks for this tool, I've often dreamed of an interactive json tool in a terminal.

This simply adds support for vim-style up/down/left/right in the main box.key input handler. It shouldn't  interfere with any existing functionality.

