### PR TITLE
Fix dangling cursor when collapsing expanded json (S-e)

### DIFF
--- a/fx.js
+++ b/fx.js
@@ -161,7 +161,7 @@ module.exports = function start(filename, source) {
   box.key('S-e', function () {
     expanded.clear()
     expanded.add('')
-    render()
+    apply()
   })
 
   box.key(['up', 'k'], function () {


### PR DESCRIPTION
When you use shift+e to collapse json, the cursor is getting left behind, which not only looks funny, but makes it impossible to key-up and key-down, because the bounds checking fails. Any left/right action also throws an exception due to the fact that the cursor is on an `undefined` line.

![image](https://user-images.githubusercontent.com/1566363/49673078-16041b00-fa22-11e8-9c24-527b208b09ac.png)
