### PR TITLE
Add snapcraft support for building snaps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: fx
 base: core18 # the base snap is the execution environment for this snap
 version: git
-summary: Command-line tool and terminal JSON viewer 🔥
+summary: Command-line tool and terminal JSON viewer
 description: |
   Command-line JSON processing tool
   Features

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,26 @@
+name: fx
+base: core18 # the base snap is the execution environment for this snap
+version: git
+summary: Command-line tool and terminal JSON viewer 🔥
+description: |
+  Command-line JSON processing tool
+  Features
+    * Formatting and highlighting
+    * Standalone binary
+    * Interactive mode tada
+    * Themes support art
+
+grade: stable
+confinement: strict
+
+parts:
+  fx:
+    plugin: nodejs
+    nodejs-version: "8.14.0"
+    source: .
+
+apps:
+  fx:
+    command: fx
+    plugs:
+      - network

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,9 +6,8 @@ description: |
   Command-line JSON processing tool
   Features
     * Formatting and highlighting
-    * Standalone binary
-    * Interactive mode tada
-    * Themes support art
+    * Interactive mode
+    * Themes support
 
 grade: stable
 confinement: strict


### PR DESCRIPTION
I’ve been using fx for a while to make consumption of various APIs more palatable on the command line. I wish I’d know about it earlier, as it’s far superior to jq! :)

This pull request enables creation of a snap package of fx. The single snap (built for many architectures) in the Snap Store will be installable on numerous popular Linux distributions with no changes. It’ll also be discoverable via the [Snap Store](https://snapcraft.io/store), where releases are under your control.

If you're willing to publish this under the fx project name, you just need to [create an account](https://snapcraft.io/snaps) and then [register the fx name](https://snapcraft.io/register-snap).

A snap file created by snapcraft (our free software tool for building snaps) can then be released in the Snap Store with `snap push --release stable *.snap`. You'll want to install snapcraft (brew install snapcraft, snap install snapcraft, or apt install snapcraft) and login (snapcraft login) first, though.

You may also want to consider using [https://build.snapcraft.io/](https://build.snapcraft.io/) which is a free build service, that can create armhf, amd64, i386, arm64 and other builds of fx, and push them to the store automatically. Alternatively it’s possible to integrate publishing the snap via a third party CI system such as travis or circle-ci.

I appreciate snaps and snapcraft may be a new thing to you, so I’d be happy to answer any questions you may have. 
