### PR TITLE
Only build on supported architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,12 @@ description: |
     * Interactive mode
     * Themes support
 
+architectures:
+  - build-on: i386
+  - build-on: amd64
+  - build-on: armhf
+  - build-on: arm64
+
 grade: stable
 confinement: strict
 


### PR DESCRIPTION
As per comment in #53 - looks like nodejs isn't supported on [s390x]https://launchpadlibrarian.net/401523666/buildlog_snap_ubuntu_xenial_s390x_d862f303dc85a1886a1db80b5e691216-xenial_BUILDING.txt.gz) and [ppc64el](https://launchpadlibrarian.net/401523830/buildlog_snap_ubuntu_xenial_ppc64el_d862f303dc85a1886a1db80b5e691216-xenial_BUILDING.txt.gz). This change tells the build system to only build on the listed supported architectures.