### PR TITLE
Gitpod integration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+- init: >
+    npm install &&
+    npm run build
+  command: >
+    ./dist/fx-linux package.json

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ curl ... | fx .message
 
 Pass any numbers of arguments as code.
 ```bash
-$ curl ... | fx 'json => json.message' 'json => json.filter(x => x.startsWith("a"))' 
+$ curl ... | fx 'json => json.message' 'json => json.filter(x => x.startsWith("a"))'
 ```
 
 Access all lodash (or ramda, etc) methods by using [.fxrc](https://github.com/antonmedv/fx/blob/master/docs.md#using-fxrc) file.
@@ -95,6 +95,26 @@ See full [documentation](https://github.com/antonmedv/fx/blob/master/docs.md).
 * [fx-theme-monokai](https://github.com/antonmedv/fx-theme-monokai) – monokai theme
 * [fx-theme-night](https://github.com/antonmedv/fx-theme-night) – night theme
 
+## Contributing
+
+Open the repo in Gitpod, the free online dev environment for GitHub.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/antonmedv/fx)
+
+Or clone locally and run:
+
+```sh
+# install dependencies
+npm install
+
+# run the build
+npm run build
+
+# try the built binary
+./dist/fx-linux package.json
+
+```
+
 ## License
 
-[MIT](https://github.com/antonmedv/fx/blob/master/LICENSE)  
+[MIT](https://github.com/antonmedv/fx/blob/master/LICENSE)


### PR DESCRIPTION
This PR adds a contributing section including support for Gitpod, a free online dev environment for GitHub, that starts the open-source Theia editor in a browser backed by a container with a full terminal.

This way contributors and other interested developers can start coding and trying **fx** with a single click right in the browser. I configured the startup so that the following tasks get executed (similar to the description for local dev):

```sh
npm install
npm run build
./dist/fx-linux package.json
```

Here is what it looks like:

<img width="1244" alt="screenshot 2019-01-21 at 09 55 27" src="https://user-images.githubusercontent.com/372735/51463332-3d5d4000-1d63-11e9-91da-f0504ca1135e.png">

You can try it out yourself: 
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/svenefftinge/fx)

