### PR TITLE
feat: add cmd support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@medv/blessed": "^1.1.1",
     "chalk": "^2.4.1",
     "indent-string": "^3.2.0",
+    "reopen-tty": "^1.1.2",
     "string-width": "^2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Cross platform `reopen-tty` package is used to resolve tty error in cmd

Tested on:

- cmd (node v8.15.0) (Tests are failing because [fx method](https://github.com/antonmedv/fx/blob/9dac9222e05180ec574baf203596849768249cda/test.js#L5) is not compatible with cmd)
- WSL (node v8.11.2) (Tests are passing)
- Linux (node v8.14.0) (Tests are passing)

This will close https://github.com/antonmedv/fx/issues/63 if all goes well.

Note that functionality in cmd is still limited. We cannot expand a node using `mouse click`. `right arrow` can be used for this purpose.