### PR TITLE
[doc]Update NODE_PATH for nvm user

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -119,7 +119,7 @@ curl 'https://api.github.com/repos/facebook/react/commits?per_page=100' \
 
 > To be able require global modules make sure you have correct `NODE_PATH` env variable.
 > ```bash
-> export NODE_PATH=/usr/local/lib/node_modules
+> export NODE_PATH=`npm root -g`
 > ```
 
 ## Edit in place


### PR DESCRIPTION
This PR will ease the installation of fx with lodash for user of [the Node Version Manager](https://github.com/creationix/nvm/blob/master/README.md). It doesn't break any compatibility since it uses the official npm command 'root -g'.

nvm users can also append this line in their .bashrc or .zshrc file:
```bash
export NODE_PATH=$NODE_PATH:`npm root -g`
```