### PR TITLE
Simplify streaming by splitting the buffer by line.

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ function stream() {
 
   return {
     isStream() {
-      return count > 1
+      return count > 0
     },
     value() {
       return buff


### PR DESCRIPTION
This simplifies the streaming mode. In the docs it says that the input must be line delimited json. Is there any reason that the implementation shouldn't actually just split on the lines? If it just assumes that each line is json anything that doesn't follow this will throw a json error produced by JSON.parse() anyway.

Addresses https://github.com/antonmedv/fx/issues/93