### PR TITLE
Extract sub-object in interactive mode

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -41,6 +41,12 @@ You can also force interactive mode with `-I` flag:
 $ curl ... | fx .foo.bar -I
 ```
 
+Or force uninteractive mode with `+I` flag:
+
+```bash
+$ curl ... | fx +I
+```
+
 If any argument was passed, `fx` will apply it and prints to stdout.
 
 ## Usage

--- a/DOCS.md
+++ b/DOCS.md
@@ -35,6 +35,12 @@ Or you can pass a filename as the first parameter:
 $ fx my.json
 ```
 
+You can also force interactive mode with `-I` flag:
+
+```bash
+$ curl ... | fx .foo.bar -I
+```
+
 If any argument was passed, `fx` will apply it and prints to stdout.
 
 ## Usage
@@ -280,6 +286,7 @@ Next commands available in interactive mode:
 | `n`                           | Find next                                    |
 | `p`                           | Exit and print JSON to stdout                |
 | `P`                           | Exit and print fully expanded JSON to stdout |
+| `x` or `Ctrl`+`e`             | Exit and print selected sub-JSON to stdout   |
 
 These commands are available when editing the filter:
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -35,18 +35,6 @@ Or you can pass a filename as the first parameter:
 $ fx my.json
 ```
 
-You can also force interactive mode with `-I` flag:
-
-```bash
-$ curl ... | fx .foo.bar -I
-```
-
-Or force uninteractive mode with `+I` flag:
-
-```bash
-$ curl ... | fx +I
-```
-
 If any argument was passed, `fx` will apply it and prints to stdout.
 
 ## Usage

--- a/fx.js
+++ b/fx.js
@@ -7,6 +7,7 @@ const reduce = require('./reduce')
 const print = require('./print')
 const find = require('./find')
 const config = require('./config')
+const LosslessJSON = require('lossless-json')
 
 module.exports = function start(filename, source, prev = {}) {
   // Current rendered object on a screen.
@@ -432,13 +433,28 @@ module.exports = function start(filename, source, prev = {}) {
     printJson()
   })
 
+  box.key(['x', 'C-e'], function () {
+    printJson({extract_subjson: true})
+  })
+
   function printJson(options = {}) {
+    var out
+    if (options.extract_subjson) {
+      const [n] = getLine(program.y)
+      const path = index.get(n)
+      const subJson = reduce(json, 'this' + path)
+      out = LosslessJSON.stringify({
+        path:  path,
+        value: subJson,
+      }, null, config.space)
+    } else {
+      [out] = print(json, options)
+    }
     screen.destroy()
     program.disableMouse()
     program.destroy()
     setTimeout(() => {
-      const [text] = print(json, options)
-      console.log(text)
+      console.log(out)
       process.exit(0)
     }, 10)
   }

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ void function main() {
     global.FX_FILENAME = filename
     args.shift()
   } else {
-    input = fs.readFileSync(process.stdin.fd, 'utf-8')
+    input = fs.readFileSync("/dev/stdin", 'utf-8')
     interactive |= args.length == 0
   }
 

--- a/index.js
+++ b/index.js
@@ -45,22 +45,18 @@ const usage = `
 
 const {stdin, stdout, stderr} = process
 var args = process.argv.slice(2)
-var interactive = false
-
-function flag(f) {
-  if (args.indexOf(f) >= 0) {
-    args = args.filter(a => a != f)
-    return true
-  } else {
-    return false
-  }
-}
 
 void function main() {
-  interactive |= flag('-I')
+  var interactive = false
 
-  let input = '';
+  let input = ''
   let filename = 'fx'
+
+  function load_file(fn) {
+    input = fs.readFileSync(fn).toString('utf8')
+    filename = path.basename(fn)
+    global.FX_FILENAME = fn
+  }
 
   if (stdin.isTTY) {
     if (args.length === 0 || (args.length === 1 && (args[0] === '-h' || args[0] === '--help'))) {
@@ -75,17 +71,16 @@ void function main() {
       require('./bang')
       return
     }
-
-    input = fs.readFileSync(args[0]).toString('utf8')
-    filename = path.basename(args[0])
-    global.FX_FILENAME = filename
+    load_file(args[0])
+    args.shift()
+  } else if (args.length > 0 &&
+             fs.existsSync(args[0]) && fs.statSync(args[0]).isFile()) {
+    load_file(args[0])
     args.shift()
   } else {
     input = fs.readFileSync("/dev/stdin", 'utf-8')
     interactive |= args.length == 0
   }
-
-  interactive &= !flag('+I')
 
   let json
   try {

--- a/index.js
+++ b/index.js
@@ -47,11 +47,17 @@ const {stdin, stdout, stderr} = process
 var args = process.argv.slice(2)
 var interactive = false
 
-void function main() {
-  if (args.indexOf('-I') >= 0) {
-    args = args.filter(a => a != '-I')
-    interactive = true
+function flag(f) {
+  if (args.indexOf(f) >= 0) {
+    args = args.filter(a => a != f)
+    return true
+  } else {
+    return false
   }
+}
+
+void function main() {
+  interactive |= flag('-I')
 
   let input = '';
   let filename = 'fx'
@@ -78,6 +84,8 @@ void function main() {
     input = fs.readFileSync(process.stdin.fd, 'utf-8')
     interactive |= args.length == 0
   }
+
+  interactive &= !flag('+I')
 
   let json
   try {

--- a/test.js
+++ b/test.js
@@ -3,8 +3,8 @@ const test = require('ava')
 const {execSync} = require('child_process')
 const stream = require('./stream')
 
-function fx(json, code = '') {
-  return execSync(`echo '${JSON.stringify(json)}' | node index.js ${code} +I`).toString('utf8')
+function fx(json, code = '.') {
+  return execSync(`echo '${JSON.stringify(json)}' | node index.js ${code}`).toString('utf8')
 }
 
 test('pass', t => {

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ const {execSync} = require('child_process')
 const stream = require('./stream')
 
 function fx(json, code = '') {
-  return execSync(`echo '${JSON.stringify(json)}' | node index.js ${code}`).toString('utf8')
+  return execSync(`echo '${JSON.stringify(json)}' | node index.js ${code} +I`).toString('utf8')
 }
 
 test('pass', t => {

--- a/test.js
+++ b/test.js
@@ -83,3 +83,14 @@ test('value iterator simple', t => {
   const r = fx([{val:1},{val:2}], '.[].val')
   t.deepEqual(JSON.parse(r), [1, 2])
 })
+
+test('streaming from stdin', t => {
+  const r = execSync(`
+  {
+    echo '{"a":1}';
+    echo '{"a":2}';
+    echo '{"a":3}';
+  } | node index.js .a`).toString('utf8')
+  t.is(r, '1\n2\n3\n')
+})
+


### PR DESCRIPTION
When sub-object is selected in interactive mode, by pressing `x` or `Ctrl-e` sub-object is printed to stdout in this form:
```
$ <t2.json fx
{
  "a": 11,
  "b": {
    "c": 33
  }
}

$ <t2.json fx # .b is interactively selected, key `x` is pressed
{
  "path": ".b",
  "value": {
    "c": 33
  }
}
```

I had to do some changes around handling piped/TTY input and output and command line arguments. 
It should support all existing modes of use.

This should also close #132

Best regards!

_UPDATE:_ I removed anything about completely unneeded interactive mode forcing flags. PR is now only about interactive mode action for extraction of sub-object to support semi-interactive workflows discussed in the PR.