### PR TITLE
fix: set exit code to zero when fx --version

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function handle(input) {
     }
     if (args.length === 1 && (args[0] === '-v' || args[0] === '--version')) {
       stderr.write(require('./package.json').version + '\n')
-      process.exit(2)
+      process.exit(0)
     }
     if (args.length === 1 && args[0] === '--life') {
       require('./bang')


### PR DESCRIPTION
As it's the current convention.