### PR TITLE
Flexible .fxrc location

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,10 @@ JSON.config({circularRefs: false})
 const std = require('./std')
 
 try {
-  require(path.join(os.homedir(), '.fxrc')) // Should be required before config.js usage.
+  let fxrcPath = fs.existsSync(path.join(process.cwd(), '.fxrc'))
+    ? path.join(process.cwd(), '.fxrc')
+    : path.join(os.homedir(), '.fxrc');
+  require(fxrcPath) // Should be required before config.js usage.
 } catch (err) {
   if (err.code !== 'MODULE_NOT_FOUND') {
     throw err
@@ -23,14 +26,14 @@ const stream = require('./stream')
 
 const usage = `
   Usage
-    $ fx [code ...]               
+    $ fx [code ...]
 
   Examples
     $ echo '{"key": "value"}' | fx 'x => x.key'
     value
 
     $ echo '{"key": "value"}' | fx .key
-    value    
+    value
 
     $ echo '[1,2,3]' | fx 'this.map(x => x * 2)'
     [2, 4, 6]


### PR DESCRIPTION
Hi @antonmedv, 

This is just a little improvement, to let users choose where tu put their *.fxrc*.

It looks in the current directory first. If *.fxrc* exists it uses that. 

With this approach, you don't have to install npm packages globally. All the user have to do is:

```bash
npm init --yes; npm i <the_package>
```
The user can have now the best of both worlds. If they want to keep it using the same way, no problem . If the user prefers to have their packages installed locally, he/she can do it as well. 

I'm aware it's a tradeoff in some way, but i think it's worth to take a look, 

What do you think?

Cheers!
