### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cat foo.json bar.json baz.json | fx .message
 
 Use full power of JavaScript.
 ```bash
-$ curl ... | fx '.filter(x => x.startsWith("a"))'
+$ curl ... | fx 'filter(x => x.startsWith("a"))'
 ```
 
 Access all lodash (or ramda, etc) methods by using [.fxrc](https://github.com/antonmedv/fx/blob/master/DOCS.md#using-fxrc) file.


### PR DESCRIPTION
Update `README.md`.

'.filter' will result in "TypeError: this.filter is not a function". Change to 'filter' (as seen in the full documentation examples)

Other examples of main README weren't tested for this pr.