### PR TITLE
Add extra keybindings for completion

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -290,6 +290,7 @@ These commands are available when editing the filter:
 | `Ctrl`+`u`                    | Clear filter            |
 | `Ctrl`+`w`                    | Delete last part        |
 | `up`/`down`                   | Select autocomplete     |
+| `Ctrl+p`/`Ctrl+n`             | Select autocomplete     |
 
 ### Searching
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -290,7 +290,7 @@ These commands are available when editing the filter:
 | `Ctrl`+`u`                    | Clear filter            |
 | `Ctrl`+`w`                    | Delete last part        |
 | `up`/`down`                   | Select autocomplete     |
-| `Ctrl+p`/`Ctrl+n`             | Select autocomplete     |
+| `Ctrl`+`p`/`Ctrl`+`n`         | Select autocomplete     |
 
 ### Searching
 

--- a/fx.js
+++ b/fx.js
@@ -189,6 +189,20 @@ module.exports = function start(filename, source, prev = {}) {
     }
   })
 
+  input.key('C-p', function () {
+    if (!autocomplete.hidden) {
+      autocomplete.up()
+      screen.render()
+    }
+  })
+
+  input.key('C-n', function () {
+    if (!autocomplete.hidden) {
+      autocomplete.down()
+      screen.render()
+    }
+  })
+
   input.key('C-u', function () {
     input.setValue('')
     update('')


### PR DESCRIPTION
Add `Ctrl`+`p` and `Ctrl`+`n` for choosing _previous_ and _next_ completion options.
Updated documentation also.