### PR TITLE
Prevent "reduce" name collision

### DIFF
--- a/reduce.js
+++ b/reduce.js
@@ -1,7 +1,7 @@
 'use strict'
 const JSON = require('lossless-json') // override JSON for user's code
 
-function reduce(json, code) {
+module.exports = function (json, code) {
   if (process.env.FX_APPLY) {
     return global[process.env.FX_APPLY](code)(json)
   }
@@ -47,5 +47,3 @@ function reduce(json, code) {
   }
   return fn
 }
-
-module.exports = reduce


### PR DESCRIPTION
.fxrc:
```
global._ = require('lodash/fp');
Object.assign(global, _);
```

Before:
```
$ echo '[2, 3, 4]' | fx 'reduce(multiply, 1)'
1 # Huh?
```

After:
```
$ echo '[2, 3, 4]' | fx 'reduce(multiply, 1)'
24
```