### PR TITLE
Fix invalid array length with FX_SHOW_SIZE

### DIFF
--- a/print.go
+++ b/print.go
@@ -169,7 +169,7 @@ func (m *model) preview(v interface{}, path string, selectableValues bool) strin
 		}
 		if len(v) > 1 {
 			if m.showSize {
-				output += previewStyle(toLowerNumber(fmt.Sprintf(", \u2026%v\u2026", len(v)-1)))
+				output += previewStyle(toLowerNumber(fmt.Sprintf(", \u2026%v\u2026", len(v))))
 			} else {
 				output += previewStyle(", \u2026")
 			}


### PR DESCRIPTION
~~Hi, I noticed that when using FX_SHOW_SIZE the length of arrays was false, because it gets minused by 1.~~

Well, I just understood that it shows the first object and then the remaining ones, so -1... I don't find it very clear at first look, but no bug here.
I understood it in this way: first part gives info on the sub-objects, 2nd part gives the total number of objects