### PR TITLE
fix: stdout and stderr behavior

### DIFF
--- a/pkg/json/parse.go
+++ b/pkg/json/parse.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"encoding/json"
+
 	. "github.com/antonmedv/fx/pkg/dict"
 )
 

--- a/pkg/reducer/node.js
+++ b/pkg/reducer/node.js
@@ -20,8 +20,12 @@ void async function () {
 
   // Reducers %v
 
+  // Adding a line break to easily differentiate the reduced object in the output.
+  // No matter what reducers write to stdout, the reduced object will always be on the last line.
+  process.stdout.write('\n')
+
   if (typeof x === 'undefined') {
-    process.stderr.write('undefined')
+    process.stderr.write('Reducer returned undefined')
   } else {
     process.stdout.write(JSON.stringify(x))
   }

--- a/pkg/reducer/reduce.go
+++ b/pkg/reducer/reduce.go
@@ -59,6 +59,8 @@ func Reduce(input interface{}, lang string, args []string, theme Theme, fxrc str
 		status, ok := err.(*exec.ExitError)
 		if ok {
 			exitCode = status.ExitCode()
+		} else {
+			fmt.Println(err.Error())
 		}
 		fmt.Print(string(stderr.Bytes()))
 		return exitCode

--- a/pkg/reducer/utils.go
+++ b/pkg/reducer/utils.go
@@ -10,11 +10,7 @@ import (
 )
 
 func Echo(object interface{}, theme Theme) {
-	if s, ok := object.(string); ok {
-		fmt.Println(s)
-	} else {
-		fmt.Println(PrettyPrint(object, 1, theme))
-	}
+	fmt.Println(PrettyPrint(object, 1, theme))
 }
 
 func trace(args []string, i int) (pre, post, pointer string) {


### PR DESCRIPTION
I had a problem with piping `fx` to `xargs`, specifically things like this weren't working properly:
```js
global.list = json => (json.forEach(x => console.log(x)), undefined)
```

Whenever I tried to use `console.log` reducers were acting weirdly, for example:
<img width="735" alt="image" src="https://user-images.githubusercontent.com/6882605/193451106-aa54eb56-8865-4a19-8b33-0982f0a04c0b.png">

After some investigation I've realized that stderr from reducer processes was being mixed with stdout (which was the main issue) and also that pretty printing was misbehaving when stdout contained anything other than the reduced object.

So, I've cleaned up the code a little and now it works like this:
<img width="735" alt="image" src="https://user-images.githubusercontent.com/6882605/193451331-8d9b59c9-d23d-43ee-b317-f8983d9cd5ae.png">

Also, reducers now can return an object regardless of whether `console.log` was used or not. It looks like this:
<img width="734" alt="image" src="https://user-images.githubusercontent.com/6882605/193451559-d22f6b60-b524-4cfa-aec0-d4100c3d3c69.png">
