### PR TITLE
Support different styles (including ascii) for size display in preview

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,10 +72,21 @@ func main() {
 	if termenv.ColorProfile() == termenv.Ascii {
 		theme = Themes["0"]
 	}
-	var showSize bool
+    var showSizeT int = 0
 	if s, ok := os.LookupEnv("FX_SHOW_SIZE"); ok {
-		if s == "true" {
-			showSize = true
+        switch s {
+        case "subscript":
+            showSizeT = 2
+        case "mono":
+            showSizeT = 3
+        case "bold":
+            showSizeT = 4
+        case "sans":
+            showSizeT = 5
+        case "doublestruck":
+            showSizeT = 6
+        default:
+            showSizeT = 1
 		}
 	}
 
@@ -185,7 +196,7 @@ func main() {
 		fileName:        fileName,
 		theme:           theme,
 		json:            object,
-		showSize:        showSize,
+		showSize:        showSizeT,
 		width:           80,
 		height:          60,
 		mouseWheelDelta: 3,
@@ -217,7 +228,7 @@ type model struct {
 	footerHeight  int
 	wrap          bool
 	theme         Theme
-	showSize      bool // Show number of elements in preview
+	showSize      int // Show number of elements in preview (> 0)
 
 	fileName string
 	json     interface{}

--- a/print.go
+++ b/print.go
@@ -125,19 +125,19 @@ func (m *model) preview(v interface{}, path string, selectableValues bool) strin
 		case string:
 			return previewStyle(fmt.Sprintf("%q", v))
 		case *Dict:
-			if m.showSize {
-				return previewStyle(toLowerNumber(fmt.Sprintf("{\u2026%v\u2026}", len(v.Keys))))
+			if m.showSize > 0 {
+				return previewStyle(toLowerNumber(fmt.Sprintf("{\u2026%v\u2026}", len(v.Keys)), m.showSize))
 			} else {
 				return previewStyle("{\u2026}")
 			}
 		case Array:
-			if m.showSize {
-				return previewStyle(toLowerNumber(fmt.Sprintf("[\u2026%v\u2026]", len(v))))
+			if m.showSize > 0 {
+				return previewStyle(toLowerNumber(fmt.Sprintf("[\u2026%v\u2026]", len(v)), m.showSize))
 			} else {
 				return previewStyle("[\u2026]")
 			}
 		}
-		return "..."
+		return ".-.-."
 	}
 
 	switch v := v.(type) {
@@ -152,8 +152,8 @@ func (m *model) preview(v interface{}, path string, selectableValues bool) strin
 			break
 		}
 		if len(keys) > 1 {
-			if m.showSize {
-				output += previewStyle(toLowerNumber(fmt.Sprintf(", \u2026%v\u2026", len(v.Keys)-1)))
+			if m.showSize > 0 {
+				output += previewStyle(toLowerNumber(fmt.Sprintf(", \u2026%v\u2026", len(v.Keys)-1), m.showSize))
 			} else {
 				output += previewStyle(", \u2026")
 			}
@@ -168,8 +168,8 @@ func (m *model) preview(v interface{}, path string, selectableValues bool) strin
 			break
 		}
 		if len(v) > 1 {
-			if m.showSize {
-				output += previewStyle(toLowerNumber(fmt.Sprintf(", \u2026%v\u2026", len(v)-1)))
+			if m.showSize > 0 {
+				output += previewStyle(toLowerNumber(fmt.Sprintf(", \u2026%v\u2026", len(v)-1), m.showSize))
 			} else {
 				output += previewStyle(", \u2026")
 			}

--- a/util.go
+++ b/util.go
@@ -36,15 +36,37 @@ func accessor(path string, to interface{}) string {
 	return fmt.Sprintf("%v[%v]", path, to)
 }
 
-func toLowerNumber(s string) string {
+func toLowerNumber(s string, style int) string {
 	var out strings.Builder
+    //  Subscript            ₀₁₂₃₄₅₆₇₈₉
+    //  Math Monospace       𝟶𝟷𝟸𝟹𝟺𝟻𝟼𝟽𝟾𝟿
+    //  Math bold digit      𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗 
+    //  Math bold sans serif 𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵
+    //  Math double struck   𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟠𝟡
+    //  Ascii                0123456789
+    //
+
+
 	for _, r := range s {
 		switch {
 		case '0' <= r && r <= '9':
-			out.WriteRune('\u2080' + (r - '\u0030'))
+            switch style {
+            case 2:
+                out.WriteRune('\u2080' + (r - '\u0030')) // Subscript
+            case 3:
+                out.WriteRune('\U0001D7F6' + (r - '\u0030')) // Math Monospace
+            case 4:
+                out.WriteRune('\U0001D7CE' + (r - '\u0030')) // Math bold
+            case 5:
+                out.WriteRune('\U0001D7EC' + (r - '\u0030')) // Math bold - Sans serif
+            case 6:
+                out.WriteRune('\U0001D7D8' + (r - '\u0030')) // Math bold - Double struck
+            default:
+                out.WriteRune(r)
+            }
 		default:
 			out.WriteRune(r)
 		}
 	}
-	return out.String()
+    return out.String()
 }


### PR DESCRIPTION
Environment var FX_SHOW_SIZE can contain different styles of unicode ranges beside "subscript"

"subscript": What you would get with "true" up until this. \u2080 forward
"mono": Unicode monospace digits. \U0001D7F6 forward
"bold":  Unicode math bold digits. \U0001D7CE forward
"sans": Unicode math sans bold digits.  
"doublestruck": Unicode math doublestruck digits. \U0001D7D8 forward
"true" or any other string: Plain ascii

New comments too with preview:
+    //  Subscript            ₀₁₂₃₄₅₆₇₈₉
+    //  Math Monospace       𝟶𝟷𝟸𝟹𝟺𝟻𝟼𝟽𝟾𝟿
+    //  Math bold digit      𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗
+    //  Math bold sans serif 𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵
+    //  Math double struck   𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟠𝟡
+    //  Ascii                0123456789
