### PR TITLE
fix: create a temp dir to avoid overwriting files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-curl -sAx "https://bit.ly/fx-download-counter" > /dev/null
+curl -sAx "https://bit.ly/fx-download-counter" >/dev/null
 
 version='24.1.0'
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -33,9 +33,15 @@ arm64 | aarch64)
   ;;
 esac
 
+temp_dir=$(mktemp -d) || {
+  echo "temp dir error" >&2
+  exit 1
+}
+trap 'rm -rf $temp_dir' EXIT INT TERM HUP
+
 asset="fx_${os}_${arch}${ext}"
 echo "Installing fx ${version} (${asset})"
-curl -Lfs "https://github.com/antonmedv/fx/releases/download/${version}/${asset}" -o fx
+curl -Lfs "https://github.com/antonmedv/fx/releases/download/${version}/${asset}" -o "$temp_dir/fx"
 
-chmod +x fx
-mv fx /usr/local/bin/fx
+chmod +x "$temp_dir/fx"
+mv "$temp_dir/fx" /usr/local/bin/fx


### PR DESCRIPTION
saving files should be done either to destination or to a temporary directory to avoid the overwriting of any files that are present.
take this senario:
```console
> ls ./my-favorite-programs
fx
gh
ls
> curl https://fx.wtf | sh
Installing fx 24.1.0 (fx_linux_amd64)
> ls ./my-favorite-programs
gh
ls
```
a file has been deleted because the curl command overwrote it, and then it was moved to the final destination.
this could also cause issues if the `fx` file in the cwd did not have permissions allowing overwriting.
A far better solution (provided that writing directly to the destination is not desired) would be to create a temporary directory and copy from there.
this PR does exactly that: create a temporary directory, curl into it, move that file, and remove the directory on exit
