### PR TITLE
Added support for comments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/dlclark/regexp2 v1.9.0 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/google/pprof v0.0.0-20230406165453-00490a63f317 // indirect
+	github.com/hedhyw/jsoncjson v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5Nq
 github.com/google/pprof v0.0.0-20230207041349-798e818bf904/go.mod h1:uglQLonpP8qtYCYyzA+8c/9qtqgA3qsXGYqCPKARAFg=
 github.com/google/pprof v0.0.0-20230406165453-00490a63f317 h1:hFhpt7CTmR3DX+b4R19ydQFtofxT0Sv3QsKNMVQYTMQ=
 github.com/google/pprof v0.0.0-20230406165453-00490a63f317/go.mod h1:79YE0hCXdHag9sBkw2o+N/YnZtTkXi0UT9Nnixa5eYk=
+github.com/hedhyw/jsoncjson v1.1.0 h1:uw/aqmbSXAQNJHDPLb+DpwlPNzMREGIsrs+TIwPk+f0=
+github.com/hedhyw/jsoncjson v1.1.0/go.mod h1:++nXlbEXzRMcqkoDLvH5I/z5qBkacAWSZDt1u6osUPc=
 github.com/ianlancetaylor/demangle v0.0.0-20220319035150-800ac71e25c2/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/pkg/json/parse.go
+++ b/pkg/json/parse.go
@@ -2,7 +2,7 @@ package json
 
 import (
 	"encoding/json"
-	"os"
+	"fmt"
 	"strings"
 
 	. "github.com/antonmedv/fx/pkg/dict"
@@ -44,86 +44,299 @@ func Parse(dec *json.Decoder, data string) (interface{}, CommentsData, error) {
 }
 
 func getComments(data string) CommentsData {
+	// This function gets the comments from the json file. It first finds the positions of the comments, then parses the JSON and relates the comments to the JSON elements.
 	comments := make(CommentsData)
 
-	// Loop until we find something that isn't a comment
-	takeUntil := func(until ...string) string {
-		takenData := ""
-	take:
-		for {
-			if len(data) == 0 {
-				break
-			}
-			// Check if any of the until strings are at the start of the data
-			for _, u := range until {
-				if strings.HasPrefix(data, u) {
-					data = data[len(u):]
-					break take
-				}
-			}
-			takenData += string(data[0])
-			data = data[1:]
-		}
-		return takenData
+	// Find the positions of the comments.
+	// Comments may be inline or block comments.
+	// Inline comments are of the form "// comment"
+	// Block comments are of the form "/* comment */"
+	type commentPosition struct {
+		Position int
+		Type     int
+		Content  string
 	}
 
-	path := ""
+	commentPositions := make([]commentPosition, 0)
 
-	takeComments := func() {
-		// Comments at the start
-		for len(data) > 0 {
-			data = strings.TrimSpace(data)
-			if strings.HasPrefix(data, "//") {
-				if comments[path] == nil {
-					comments[path] = &CommentData{}
+	// Remove all the strings from the data
+	// This is done so that the comments inside strings are not counted
+	const (
+		NoString          = iota
+		SingleQuoteString = iota
+		DoubleQuoteString = iota
+	)
+	stringType := NoString
+	escape := false
+	for index := 0; index < len(data); index++ {
+		char := string(data[index])
+
+		if escape {
+			escape = false
+			continue
+		}
+
+		if char == "\"" && stringType == NoString {
+			stringType = DoubleQuoteString
+		} else if char == "\"" && stringType == DoubleQuoteString {
+			stringType = NoString
+		} else if char == "'" && stringType == NoString {
+			stringType = SingleQuoteString
+		} else if char == "'" && stringType == SingleQuoteString {
+			stringType = NoString
+		} else if char == "\\" {
+			escape = true
+		}
+
+		// If we're not in a string, check for comments
+		if stringType == NoString {
+			dataPart := data[index:]
+			// Inline comments
+			if strings.HasPrefix(dataPart, "//") {
+				// Inline comment
+				comment := ""
+				for _, c := range dataPart {
+					if c == '\n' {
+						break
+					}
+					comment += string(c)
 				}
-				comments[path].CommentsBefore = append(comments[path].CommentsBefore, Comment{
-					Comment: strings.Trim(strings.TrimPrefix(takeUntil("\n"), "//"), " "),
-					Type:    InlineComment,
+
+				commentPositions = append(commentPositions, commentPosition{
+					Position: index,
+					Type:     InlineComment,
+					Content:  comment,
 				})
-			} else if strings.HasPrefix(data, "/*") {
-				if comments[path] == nil {
-					comments[path] = &CommentData{}
+
+				// Remove the comment from the data
+				data = data[:index] + data[index+len(comment):]
+			}
+			// Block comments
+			if strings.HasPrefix(dataPart, "/*") {
+				// Block comment
+				comment := ""
+				for _, c := range dataPart {
+					if strings.HasSuffix(comment, "*/") {
+						break
+					}
+					comment += string(c)
 				}
-				comments[path].CommentsBefore = append(comments[path].CommentsBefore, Comment{
-					Comment: strings.Trim(strings.TrimPrefix(takeUntil("*/"), "/*"), " "),
-					Type:    BlockComment,
+
+				commentPositions = append(commentPositions, commentPosition{
+					Position: index,
+					Type:     BlockComment,
+					Content:  comment,
 				})
-			} else {
-				break
+
+				// Remove the comment from the data
+				data = data[:index] + data[index+len(comment):]
 			}
 		}
-		return
 	}
 
-	takeComments()
+	// Data should now be parsable by the JSON decoder. Parse it and find the path to every character.
+	characterToPath, err := getPathCharacters(data)
+	if err != nil {
+		return nil
+	}
 
-	// Half-parse the JSON (We don't care about the values, just getting the path and comments).
-	// We can't use a JSON parser because it will error on the comments.
-	for len(data) > 0 {
-		takeUntil("//", "/*")
-		takeComments()
+	maxKey := 0
+	for k := range characterToPath {
+		if k > int64(maxKey) {
+			maxKey = int(k)
+		}
+	}
+
+	// For each comment, find the path
+	totalAdded := 0
+	for _, c := range commentPositions {
+		character := int64(c.Position)
+		if character < 0 {
+			character = 0
+		}
+		if character > int64(maxKey)-1 {
+			character = int64(maxKey)
+		}
+
+		commentPath, ok := characterToPath[character]
+		if !ok {
+			println("didn't exist uh oh ", c.Position, character, totalAdded, len(data))
+			continue
+		}
+
+		_, ok = comments[commentPath]
+		if !ok {
+			comments[commentPath] = &CommentData{
+				CommentsBefore: []Comment{},
+				CommentAt:      Comment{},
+				CommentsAfter:  []Comment{},
+			}
+		}
+
+		content := c.Content
+		if c.Type == InlineComment {
+			content = strings.TrimPrefix(content, "//")
+			content = strings.TrimSpace(content)
+		} else if c.Type == BlockComment {
+			content = strings.TrimPrefix(content, "/*")
+			content = strings.TrimSuffix(content, "*/")
+			lines := strings.Split(content, "\n")
+			for i, line := range lines {
+				lines[i] = strings.Trim(line, " \t")
+			}
+			content = strings.Join(lines, "\n")
+			println(content)
+		}
+
+		comments[commentPath].CommentsBefore = append(comments[commentPath].CommentsBefore, Comment{
+			Comment: content,
+			Type:    c.Type,
+		})
+		totalAdded += len(c.Content)
 	}
 
 	// Print the comments
-	for k, v := range comments {
-		println("'" + k + "':")
-		println("  Before:")
-		for _, c := range v.CommentsBefore {
-			println("   | ", k, ":", strings.Split(c.Comment, "\n")[0])
-		}
-		println("  Inline:")
-		println("   | ", k, ":", v.CommentAt.Comment)
-		println("  After:")
-		for _, c := range v.CommentsAfter {
-			println("   | ", k, ":", c.Comment)
-		}
-		println("------------")
-	}
+	// for k, v := range comments {
+	// 	println("'" + k + "':")
+	// 	println("  Before:")
+	// 	for _, c := range v.CommentsBefore {
+	// 		println("   | ", k, ":", strings.Split(c.Comment, "\n")[0])
+	// 	}
+	// 	println("  Inline:")
+	// 	println("   | ", k, ":", v.CommentAt.Comment)
+	// 	println("  After:")
+	// 	for _, c := range v.CommentsAfter {
+	// 		println("   | ", k, ":", c.Comment)
+	// 	}
+	// 	println("------------")
+	// }
 
-	os.Exit(0)
+	// os.Exit(0)
 
 	return comments
+}
+
+func getPathCharacters(data string) (map[int64]string, error) {
+	dec := json.NewDecoder(strings.NewReader(data))
+	characterToPath := make(map[int64]string)
+
+	path := ""
+
+	characterToPath[0] = path
+
+	oldOffset := dec.InputOffset()
+	token, err := dec.Token()
+	offset := dec.InputOffset()
+	for i := oldOffset; i < offset; i++ {
+		characterToPath[i] = path
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if delim, ok := token.(json.Delim); ok {
+		switch delim {
+		case '{':
+			newMap, err := getDictCharacters(dec, path)
+			for k, v := range newMap {
+				characterToPath[k] = v
+			}
+			return characterToPath, err
+		case '[':
+			newMap, err := getArrayCharacters(dec, path)
+			for k, v := range newMap {
+				characterToPath[k] = v
+			}
+			return characterToPath, err
+		}
+	}
+
+	return characterToPath, nil
+}
+
+func getDictCharacters(dec *json.Decoder, path string) (map[int64]string, error) {
+	characterToPath := make(map[int64]string)
+
+	oldOffset := dec.InputOffset()
+	for {
+		token, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		if delim, ok := token.(json.Delim); ok && delim == '}' {
+			offset := dec.InputOffset()
+			for i := oldOffset; i < offset; i++ {
+				_, ok = characterToPath[i]
+				if !ok {
+					characterToPath[i] = path
+				}
+			}
+			return characterToPath, nil
+		}
+		key := token.(string)
+
+		subpath := path + "." + key
+
+		token, err = dec.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		if delim, ok := token.(json.Delim); ok {
+			switch delim {
+			case '{':
+				newMap, err := getDictCharacters(dec, subpath)
+				if err != nil {
+					return nil, err
+				}
+				for k, v := range newMap {
+					characterToPath[k] = v
+				}
+			case '[':
+				newMap, err := getArrayCharacters(dec, subpath)
+				if err != nil {
+					return nil, err
+				}
+				for k, v := range newMap {
+					characterToPath[k] = v
+				}
+			}
+		}
+	}
+}
+
+func getArrayCharacters(dec *json.Decoder, path string) (map[int64]string, error) {
+	characterToPath := make(map[int64]string)
+	for index := 0; ; index++ {
+		token, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		subpath := path + "[" + fmt.Sprint(index) + "]"
+		if delim, ok := token.(json.Delim); ok {
+			switch delim {
+			case '{':
+				newMap, err := getDictCharacters(dec, subpath)
+				if err != nil {
+					return nil, err
+				}
+				for k, v := range newMap {
+					characterToPath[k] = v
+				}
+			case '[':
+				newMap, err := getArrayCharacters(dec, subpath)
+				if err != nil {
+					return nil, err
+				}
+				for k, v := range newMap {
+					characterToPath[k] = v
+				}
+			case ']':
+				return characterToPath, nil
+			}
+			continue
+		}
+	}
 }
 
 func decodeDict(dec *json.Decoder) (*Dict, error) {

--- a/pkg/json/parse.go
+++ b/pkg/json/parse.go
@@ -2,23 +2,122 @@ package json
 
 import (
 	"encoding/json"
+
 	. "github.com/antonmedv/fx/pkg/dict"
 )
 
-func Parse(dec *json.Decoder) (interface{}, error) {
+type CommentsData map[string]*CommentData
+type CommentData struct {
+	CommentsBefore []Comment
+	CommentAt      Comment
+	CommentsAfter  []Comment
+}
+type Comment struct {
+	Comment string
+	Type    int
+}
+
+const (
+	InlineComment = iota
+	BlockComment  = iota
+)
+
+func Parse(dec *json.Decoder, data string) (interface{}, CommentsData, error) {
 	token, err := dec.Token()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	comments := getComments(data)
 	if delim, ok := token.(json.Delim); ok {
 		switch delim {
 		case '{':
-			return decodeDict(dec)
+			output, err := decodeDict(dec)
+			return output, comments, err
 		case '[':
-			return decodeArray(dec)
+			output, err := decodeArray(dec)
+			return output, comments, err
 		}
 	}
-	return token, nil
+	return token, comments, nil
+}
+
+func getComments(data string) CommentsData {
+	comments := make(CommentsData)
+
+	// // Loop until we find something that isn't a comment
+	// takeUntil := func(until ...string) string {
+	// 	takenData := ""
+	// 	for {
+	// 		if len(data) == 0 {
+	// 			break
+	// 		}
+	// 		// Check if any of the until strings are at the start of the data
+	// 		for _, u := range until {
+	// 			if strings.HasPrefix(data, u) {
+	// 				data = data[len(u):]
+	// 				break
+	// 			}
+	// 		}
+	// 		takenData += string(data[0])
+	// 		data = data[1:]
+	// 	}
+	// 	return takenData
+	// }
+
+	// path := ""
+
+	// takeComments := func() {
+	// 	// Comments at the start
+	// 	for len(data) > 0 {
+	// 		data = strings.TrimSpace(data)
+	// 		if strings.HasPrefix(data, "//") {
+	// 			if comments[path] == nil {
+	// 				comments[path] = &CommentData{}
+	// 			}
+	// 			comments[path].CommentsBefore = append(comments[path].CommentsBefore, Comment{
+	// 				Comment: strings.Trim(strings.TrimPrefix(takeUntil("\n"), "//"), " "),
+	// 				Type:    InlineComment,
+	// 			})
+	// 		} else if strings.HasPrefix(data, "/*") {
+	// 			if comments[path] == nil {
+	// 				comments[path] = &CommentData{}
+	// 			}
+	// 			comments[path].CommentsBefore = append(comments[path].CommentsBefore, Comment{
+	// 				Comment: strings.Trim(strings.TrimPrefix(takeUntil("*/"), "/*"), " "),
+	// 				Type:    BlockComment,
+	// 			})
+	// 		} else {
+	// 			break
+	// 		}
+	// 	}
+	// 	return
+	// }
+
+	// takeComments()
+
+	// Half-parse the JSON (We don't care about the values, just getting the path and comments).
+	// We can't use a JSON parser because it will error on the comments.
+	// for len(data) > 0 {
+	// 	takeUntil("//", "/*")
+	// 	takeComments()
+	// }
+
+	// Print the comments
+	// for k, v := range comments {
+	// 	println("Before:")
+	// 	for _, c := range v.CommentsBefore {
+	// 		println(" | ", k, ":", strings.Split(c.Comment, "\n")[0])
+	// 	}
+	// 	println("Inline:")
+	// 	println(" | ", k, ":", v.CommentAt.Comment)
+	// 	println("After:")
+	// 	for _, c := range v.CommentsAfter {
+	// 		println(" | ", k, ":", c.Comment)
+	// 	}
+	// 	println("------------")
+	// }
+
+	return comments
 }
 
 func decodeDict(dec *json.Decoder) (*Dict, error) {

--- a/pkg/json/parse.go
+++ b/pkg/json/parse.go
@@ -2,6 +2,8 @@ package json
 
 import (
 	"encoding/json"
+	"os"
+	"strings"
 
 	. "github.com/antonmedv/fx/pkg/dict"
 )
@@ -44,78 +46,82 @@ func Parse(dec *json.Decoder, data string) (interface{}, CommentsData, error) {
 func getComments(data string) CommentsData {
 	comments := make(CommentsData)
 
-	// // Loop until we find something that isn't a comment
-	// takeUntil := func(until ...string) string {
-	// 	takenData := ""
-	// 	for {
-	// 		if len(data) == 0 {
-	// 			break
-	// 		}
-	// 		// Check if any of the until strings are at the start of the data
-	// 		for _, u := range until {
-	// 			if strings.HasPrefix(data, u) {
-	// 				data = data[len(u):]
-	// 				break
-	// 			}
-	// 		}
-	// 		takenData += string(data[0])
-	// 		data = data[1:]
-	// 	}
-	// 	return takenData
-	// }
+	// Loop until we find something that isn't a comment
+	takeUntil := func(until ...string) string {
+		takenData := ""
+	take:
+		for {
+			if len(data) == 0 {
+				break
+			}
+			// Check if any of the until strings are at the start of the data
+			for _, u := range until {
+				if strings.HasPrefix(data, u) {
+					data = data[len(u):]
+					break take
+				}
+			}
+			takenData += string(data[0])
+			data = data[1:]
+		}
+		return takenData
+	}
 
-	// path := ""
+	path := ""
 
-	// takeComments := func() {
-	// 	// Comments at the start
-	// 	for len(data) > 0 {
-	// 		data = strings.TrimSpace(data)
-	// 		if strings.HasPrefix(data, "//") {
-	// 			if comments[path] == nil {
-	// 				comments[path] = &CommentData{}
-	// 			}
-	// 			comments[path].CommentsBefore = append(comments[path].CommentsBefore, Comment{
-	// 				Comment: strings.Trim(strings.TrimPrefix(takeUntil("\n"), "//"), " "),
-	// 				Type:    InlineComment,
-	// 			})
-	// 		} else if strings.HasPrefix(data, "/*") {
-	// 			if comments[path] == nil {
-	// 				comments[path] = &CommentData{}
-	// 			}
-	// 			comments[path].CommentsBefore = append(comments[path].CommentsBefore, Comment{
-	// 				Comment: strings.Trim(strings.TrimPrefix(takeUntil("*/"), "/*"), " "),
-	// 				Type:    BlockComment,
-	// 			})
-	// 		} else {
-	// 			break
-	// 		}
-	// 	}
-	// 	return
-	// }
+	takeComments := func() {
+		// Comments at the start
+		for len(data) > 0 {
+			data = strings.TrimSpace(data)
+			if strings.HasPrefix(data, "//") {
+				if comments[path] == nil {
+					comments[path] = &CommentData{}
+				}
+				comments[path].CommentsBefore = append(comments[path].CommentsBefore, Comment{
+					Comment: strings.Trim(strings.TrimPrefix(takeUntil("\n"), "//"), " "),
+					Type:    InlineComment,
+				})
+			} else if strings.HasPrefix(data, "/*") {
+				if comments[path] == nil {
+					comments[path] = &CommentData{}
+				}
+				comments[path].CommentsBefore = append(comments[path].CommentsBefore, Comment{
+					Comment: strings.Trim(strings.TrimPrefix(takeUntil("*/"), "/*"), " "),
+					Type:    BlockComment,
+				})
+			} else {
+				break
+			}
+		}
+		return
+	}
 
-	// takeComments()
+	takeComments()
 
 	// Half-parse the JSON (We don't care about the values, just getting the path and comments).
 	// We can't use a JSON parser because it will error on the comments.
-	// for len(data) > 0 {
-	// 	takeUntil("//", "/*")
-	// 	takeComments()
-	// }
+	for len(data) > 0 {
+		takeUntil("//", "/*")
+		takeComments()
+	}
 
 	// Print the comments
-	// for k, v := range comments {
-	// 	println("Before:")
-	// 	for _, c := range v.CommentsBefore {
-	// 		println(" | ", k, ":", strings.Split(c.Comment, "\n")[0])
-	// 	}
-	// 	println("Inline:")
-	// 	println(" | ", k, ":", v.CommentAt.Comment)
-	// 	println("After:")
-	// 	for _, c := range v.CommentsAfter {
-	// 		println(" | ", k, ":", c.Comment)
-	// 	}
-	// 	println("------------")
-	// }
+	for k, v := range comments {
+		println("'" + k + "':")
+		println("  Before:")
+		for _, c := range v.CommentsBefore {
+			println("   | ", k, ":", strings.Split(c.Comment, "\n")[0])
+		}
+		println("  Inline:")
+		println("   | ", k, ":", v.CommentAt.Comment)
+		println("  After:")
+		for _, c := range v.CommentsAfter {
+			println("   | ", k, ":", c.Comment)
+		}
+		println("------------")
+	}
+
+	os.Exit(0)
 
 	return comments
 }

--- a/pkg/json/parse_test.go
+++ b/pkg/json/parse_test.go
@@ -2,9 +2,10 @@ package json
 
 import (
 	"encoding/json"
-	. "github.com/antonmedv/fx/pkg/dict"
 	"strings"
 	"testing"
+
+	. "github.com/antonmedv/fx/pkg/dict"
 )
 
 func Test_parse(t *testing.T) {
@@ -14,8 +15,8 @@ func Test_parse(t *testing.T) {
 	"a": 3,
 	"slice": [{"z": "z", "1": "1"}]
 }`
-
-	p, err := Parse(json.NewDecoder(strings.NewReader(input)))
+	// TODO: Test comments
+	p, _, err := Parse(json.NewDecoder(strings.NewReader(input)), "")
 	if err != nil {
 		t.Error("JSON parse error", err)
 	}

--- a/pkg/json/parse_test.go
+++ b/pkg/json/parse_test.go
@@ -6,17 +6,24 @@ import (
 	"testing"
 
 	. "github.com/antonmedv/fx/pkg/dict"
+	"github.com/hedhyw/jsoncjson"
 )
 
 func Test_parse(t *testing.T) {
-	input := `{
-	"a": 1,
+	// Comments with random whitespace
+	input := `  // Before ""    
+{
+	"a": 1,    /* Inline ".a" */   
 	"b": 2,
+	 //   Before ".slice" 
+	"slice": [{"z": "z",/*Inline ".slice.z" */ "1": "1"}],
 	"a": 3,
-	"slice": [{"z": "z", "1": "1"}]
-}`
-	// TODO: Test comments
-	p, _, err := Parse(json.NewDecoder(strings.NewReader(input)), "")
+	"d": 4
+	/* After ".d"*/
+}
+ // After ""   `
+	reader := jsoncjson.NewReader(strings.NewReader(input))
+	p, comments, err := Parse(json.NewDecoder(reader), input)
 	if err != nil {
 		t.Error("JSON parse error", err)
 	}
@@ -26,6 +33,7 @@ func Test_parse(t *testing.T) {
 		"a",
 		"b",
 		"slice",
+		"d",
 	}
 	for i := range o.Keys {
 		if o.Keys[i] != expectedKeys[i] {
@@ -47,6 +55,77 @@ func Test_parse(t *testing.T) {
 	for i := range z.Keys {
 		if z.Keys[i] != expectedKeys[i] {
 			t.Error("Wrong key order for nested map ", i, z.Keys[i], "!=", expectedKeys[i])
+		}
+	}
+
+	if len(comments) != 6 {
+		t.Error("Wrong number of comments", len(comments))
+	}
+
+	// Map from comment to value
+	expectedComments := map[string]CommentData{
+		"": {
+			CommentsBefore: []Comment{
+				{Comment: "Before \"\"", Type: InlineComment},
+			},
+			CommentAt: Comment{Comment: "", Type: InlineComment},
+			CommentsAfter: []Comment{
+				{Comment: "After \"\"", Type: InlineComment},
+			},
+		},
+		".a": {
+			CommentsBefore: []Comment{},
+			CommentAt:      Comment{Comment: "Inline \"a\"", Type: BlockComment},
+			CommentsAfter:  []Comment{},
+		},
+		".slice": {
+			CommentsBefore: []Comment{
+				{Comment: "Before \".slice\"", Type: InlineComment},
+			},
+			CommentAt:     Comment{Comment: "", Type: InlineComment},
+			CommentsAfter: []Comment{},
+		},
+		".slice[0].z": {
+			CommentsBefore: []Comment{},
+			CommentAt:      Comment{Comment: "Inline \".slice.z\"", Type: BlockComment},
+			CommentsAfter:  []Comment{},
+		},
+		".d": {
+			CommentsBefore: []Comment{},
+			CommentAt:      Comment{Comment: "", Type: InlineComment},
+			CommentsAfter: []Comment{
+				{Comment: "After \".d\"", Type: BlockComment},
+			},
+		},
+	}
+	for key := range comments {
+		expected, ok := expectedComments[key]
+
+		if !ok {
+			continue
+		}
+
+		value := *comments[key]
+
+		if len(value.CommentsBefore) != len(expected.CommentsBefore) {
+			t.Error("Wrong number of comments before", len(value.CommentsBefore), "!=", len(expected.CommentsBefore))
+		}
+		if len(value.CommentsAfter) != len(expected.CommentsAfter) {
+			t.Error("Wrong number of comments after", len(value.CommentsAfter), "!=", len(expected.CommentsAfter))
+		}
+
+		for i := range expected.CommentsBefore {
+			if expected.CommentsBefore[i] != value.CommentsBefore[i] {
+				t.Error("Wrong comment before", i, expected.CommentsBefore[i], "!=", value.CommentsBefore[i])
+			}
+		}
+		if expected.CommentAt != value.CommentAt {
+			t.Error("Wrong comment at", expected.CommentAt, "!=", value.CommentAt)
+		}
+		for i := range expected.CommentsAfter {
+			if expected.CommentsAfter[i] != value.CommentsAfter[i] {
+				t.Error("Wrong comment after", i, expected.CommentsAfter[i], "!=", value.CommentsAfter[i])
+			}
 		}
 	}
 }

--- a/pkg/reducer/js.go
+++ b/pkg/reducer/js.go
@@ -88,7 +88,8 @@ func ReduceJS(vm *goja.Runtime, reduce goja.Callable, input interface{}, theme T
 	output := value.String()
 	dec := json.NewDecoder(strings.NewReader(output))
 	dec.UseNumber()
-	object, err := Parse(dec)
+	// We don't need comments when reducing.
+	object, _, err := Parse(dec, "")
 	if err != nil {
 		fmt.Print(output)
 		return 0

--- a/pkg/reducer/reduce.go
+++ b/pkg/reducer/reduce.go
@@ -63,7 +63,8 @@ func Reduce(input interface{}, lang string, args []string, theme Theme, fxrc str
 
 	dec := json.NewDecoder(bytes.NewReader(output))
 	dec.UseNumber()
-	object, err := Parse(dec)
+	// We don't need comments when reducing.
+	object, _, err := Parse(dec, "")
 	if err != nil {
 		fmt.Print(string(output))
 		return 0

--- a/pkg/theme/theme.go
+++ b/pkg/theme/theme.go
@@ -1,9 +1,10 @@
 package theme
 
 import (
+	"strings"
+
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mazznoer/colorgrad"
-	"strings"
 )
 
 type Theme struct {
@@ -17,6 +18,7 @@ type Theme struct {
 	Null      Color
 	Boolean   Color
 	Number    Color
+	Comment   Color
 }
 type Color func(s ...string) string
 
@@ -40,6 +42,7 @@ var Themes = map[string]Theme{
 		Null:      noColor,
 		Boolean:   noColor,
 		Number:    noColor,
+		Comment:   noColor,
 	},
 	"1": {
 		Cursor:    defaultCursor,
@@ -52,6 +55,7 @@ var Themes = map[string]Theme{
 		Null:      defaultNull,
 		Boolean:   boldFg("3"),
 		Number:    boldFg("6"),
+		Comment:   boldFg("8"),
 	},
 	"2": {
 		Cursor:    defaultCursor,
@@ -64,6 +68,7 @@ var Themes = map[string]Theme{
 		Null:      defaultNull,
 		Boolean:   fg("#F15BB5"),
 		Number:    fg("#9B5DE5"),
+		Comment:   fg("#8c8c8c"),
 	},
 	"3": {
 		Cursor:    defaultCursor,
@@ -76,6 +81,7 @@ var Themes = map[string]Theme{
 		Null:      defaultNull,
 		Boolean:   fg("#ee964b"),
 		Number:    fg("#ee964b"),
+		Comment:   fg("#8c8c8c"),
 	},
 	"4": {
 		Cursor:    defaultCursor,
@@ -88,6 +94,7 @@ var Themes = map[string]Theme{
 		Null:      defaultNull,
 		Boolean:   fg("#FF6B6B"),
 		Number:    fg("#FFD93D"),
+		Comment:   fg("#8c8c8c"),
 	},
 	"5": {
 		Cursor:    defaultCursor,
@@ -100,6 +107,7 @@ var Themes = map[string]Theme{
 		Null:      defaultNull,
 		Boolean:   boldFg("201"),
 		Number:    boldFg("201"),
+		Comment:   boldFg("244"),
 	},
 	"6": {
 		Cursor:    defaultCursor,
@@ -112,6 +120,7 @@ var Themes = map[string]Theme{
 		Null:      defaultNull,
 		Boolean:   fg("195"),
 		Number:    fg("195"),
+		Comment:   fg("244"),
 	},
 	"7": {
 		Cursor:    defaultCursor,
@@ -124,6 +133,7 @@ var Themes = map[string]Theme{
 		Null:      defaultNull,
 		Boolean:   noColor,
 		Number:    noColor,
+		Comment:   noColor,
 	},
 	"8": {
 		Cursor:    defaultCursor,
@@ -136,6 +146,7 @@ var Themes = map[string]Theme{
 		Null:      defaultNull,
 		Boolean:   noColor,
 		Number:    noColor,
+		Comment:   noColor,
 	},
 	"9": {
 		Cursor:    defaultCursor,
@@ -148,6 +159,7 @@ var Themes = map[string]Theme{
 		Null:      defaultNull,
 		Boolean:   noColor,
 		Number:    noColor,
+		Comment:   noColor,
 	},
 }
 

--- a/stream.go
+++ b/stream.go
@@ -30,7 +30,8 @@ func stream(dec *json.Decoder, object interface{}, lang string, args []string, t
 				Reduce(object, lang, args, theme, fxrc)
 			}
 		}
-		object, err = Parse(dec)
+		// Streaming doesn't support interactive mode (and thus comments), so we pass an empty string ignore them.
+		object, _, err = Parse(dec, "")
 		if err == io.EOF {
 			return 0
 		}

--- a/viewport.go
+++ b/viewport.go
@@ -121,7 +121,7 @@ func (m *model) scrollDownToCursor() {
 func (m *model) scrollUpToCursor() {
 	at := m.cursorLineNumber()
 	if at < m.offset+m.height { // cursor is above
-		m.LineUp(max(0, m.offset-at))
+		m.LineUp(max(0, m.offset-at+2))
 	} else {
 		m.SetOffset(at)
 	}


### PR DESCRIPTION
Closes #210.

I'm not sure if you would like this feature under a flag; I did some testing with huge JSON files and, unless you have tens of thousands of comments, the performance is pretty good.

I implemented it by removing the comments and parsing normally, then finding the comments after. If you think there's a better way to do this, please tell me; the code is a bit messy as this is one of my first times writing Go.

Here are some images:

JSON input:
![image](https://github.com/antonmedv/fx/assets/50056537/f206e471-b26c-4f74-ad38-21ac2643185c)
In fx:
![image](https://github.com/antonmedv/fx/assets/50056537/4a8b1424-69fb-4599-9c03-8d7c0628b18a)

Thank you for this amazing program!