### PR TITLE
feat: handle promise arrays

### DIFF
--- a/npm/index.js
+++ b/npm/index.js
@@ -51,7 +51,7 @@ async function runTransforms(json, args, theme) {
   let i, code, jsCode, output = json
   for ([i, code] of args.entries()) try {
     jsCode = transpile(code)
-    const fn = `(function () {
+    const fn = `(async function () {
       const x = this
       return ${jsCode}
     })`
@@ -109,19 +109,19 @@ function transpile(code) {
   if (/^map\(.+?\)$/i.test(code)) {
     let s = code.substring(4, code.length - 1)
     if (s[0] === '.') s = 'x' + s
-    return `x.map((x, i) => apply(${s}, x, i))`
+    return `Promise.all(x.map((x, i) => apply(${s}, x, i)))`
   }
 
   if (/^@/.test(code)) {
     const jsCode = transpile(code.substring(1))
-    return `x.map((x, i) => apply(${jsCode}, x, i))`
+    return `Promise.all(x.map((x, i) => apply(${jsCode}, x, i)))`
   }
 
   return code
 }
 
 async function run(json, code) {
-  const fn = eval(code).call(json)
+  const fn = await eval(code).call(json)
 
   return apply(fn, json)
 

--- a/npm/test.js
+++ b/npm/test.js
@@ -211,4 +211,28 @@ void async function main() {
     const {stdout} = await runSimple(`.name package.json`)
     t.equal(stdout, 'fx\n')
   })
+
+  await test("promises - promise output", async (t) => {
+    const { stdout } = await run(
+      [{ greeting: "hello world" }],
+      "'Promise.resolve(x)'",
+    );
+    t.deepEqual(stdout, '[\n  {\n    "greeting": "hello world"\n  }\n]\n');
+  });
+
+  await test("promises - map promises", async (t) => {
+    const { stdout } = await run(
+      ["foo", "bar"],
+      "'map(x=>Promise.resolve(x))'",
+    );
+    t.deepEqual(JSON.parse(stdout), ["foo", "bar"]);
+
+  });
+  await test("promises - nested promises", async (t) => {
+    const { stdout } = await run(
+      ["foo", "bar"],
+      "'map(async x=>({name: await Promise.resolve(x)}))'",
+    );
+    t.deepEqual(JSON.parse(stdout), [{ name: "foo" }, { name: "bar" }]);
+  });
 }()


### PR DESCRIPTION
## What

Currently, fx handles only promise value if it is an output.

This PR improves on that to handle also array of promises and support using `await` in expressions. Which will allow users to perform async operations inside `map` (.i.e: `map(x => fetch(x))` ).

### Before
```shell
❯ echo '[1,2,3]' | fx 'map(x=>Promise.resolve(x))'
[
  {},
  {},
  {}
]
```
### After
```shell
❯ echo '[1,2,3]' | ./fx 'map(x=>Promise.resolve(x))'
[
  1,
  2,
  3
]
```

## Ideas

Maybe fx could introduce a syntax for promises, but I really like the simplicity of `fx` and offloading everything to js runtime, which reduces parse/eval complexity.
