### PR TITLE
Add optional collection size indicator

### DIFF
--- a/json.go
+++ b/json.go
@@ -200,6 +200,7 @@ func (p *jsonParser) parseObject() *node {
 		p.depth++
 		key := p.parseString()
 		key.key, key.value = key.value, nil
+		object.size += 1
 		key.directParent = object
 
 		p.skipWhitespace()
@@ -216,6 +217,7 @@ func (p *jsonParser) parseObject() *node {
 		p.depth--
 
 		key.value = value.value
+		key.size = value.size
 		key.next = value.next
 		if key.next != nil {
 			key.next.prev = key
@@ -268,6 +270,7 @@ func (p *jsonParser) parseArray() *node {
 		p.depth++
 		value := p.parseValue()
 		value.directParent = arr
+		arr.size += 1
 		value.index = i
 		p.depth--
 

--- a/main.go
+++ b/main.go
@@ -725,6 +725,10 @@ func (m *model) View() string {
 			screen = append(screen, comma...)
 		}
 
+		if showSizes && n.isCollapsed() && (n.value[0] == '{' || n.value[0] == '[') {
+			screen = append(screen, currentTheme.Size([]byte(fmt.Sprintf(" // %d", n.size)))...)
+		}
+
 		screen = append(screen, '\n')
 		printedLines++
 		n = n.next

--- a/main_test.go
+++ b/main_test.go
@@ -101,3 +101,16 @@ func TestCollapseRecursive(t *testing.T) {
 	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
 	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
 }
+
+func TestCollapseRecursiveWithSizes(t *testing.T) {
+	showSizes = true
+	defer func() { showSizes = true }()
+
+	tm := prepare(t)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyShiftLeft})
+	teatest.RequireEqualOutput(t, read(t, tm))
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
+}

--- a/node.go
+++ b/node.go
@@ -14,6 +14,7 @@ type node struct {
 	depth           uint8
 	key             []byte
 	value           []byte
+	size            int
 	chunk           []byte
 	chunkEnd        *node
 	comma           bool

--- a/testdata/TestCollapseRecursiveWithSizes.golden
+++ b/testdata/TestCollapseRecursiveWithSizes.golden
@@ -1,0 +1,40 @@
+[?25l[7m{[0m
+  "title": "Lorem ipsum",
+  "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusm
+  od tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam
+  , quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo cons
+  equat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum d
+  olore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident
+  , sunt in culpa qui officia deserunt mollit anim id est laborum.",
+  "tags": […], // 3
+  "year": 3000,
+  "funny": true,
+  "author": {"name":…} // 2
+}
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+                                                                                [80D

--- a/theme.go
+++ b/theme.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
@@ -22,6 +23,7 @@ type theme struct {
 	Null      color
 	Boolean   color
 	Number    color
+	Size      color
 }
 
 type color func(s []byte) []byte
@@ -66,6 +68,12 @@ func init() {
 		themeId = "1"
 	}
 
+	showSizesValue, ok := os.LookupEnv("FX_SHOWSIZES")
+	if ok {
+		showSizesValue := strings.ToLower(showSizesValue)
+		showSizes = showSizesValue == "true" || showSizesValue == "yes" || showSizesValue == "on" || showSizesValue == "1"
+	}
+
 	currentTheme, ok = themes[themeId]
 	if !ok {
 		_, _ = fmt.Fprintf(os.Stderr, "fx: unknown theme %q, available themes: %v\n", themeId, themeNames)
@@ -93,6 +101,8 @@ var (
 	defaultStatusBar = toColor(lipgloss.NewStyle().Background(lipgloss.Color("7")).Foreground(lipgloss.Color("0")).Render)
 	defaultSearch    = toColor(lipgloss.NewStyle().Background(lipgloss.Color("11")).Foreground(lipgloss.Color("16")).Render)
 	defaultNull      = fg("243")
+	defaultSize      = toColor(lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Render)
+	showSizes        = false
 )
 
 var (
@@ -117,6 +127,7 @@ var themes = map[string]theme{
 		Null:      noColor,
 		Boolean:   noColor,
 		Number:    noColor,
+		Size:      noColor,
 	},
 	"1": {
 		Cursor:    defaultCursor,
@@ -129,6 +140,7 @@ var themes = map[string]theme{
 		Null:      defaultNull,
 		Boolean:   fg("5"),
 		Number:    fg("6"),
+		Size:      defaultSize,
 	},
 	"2": {
 		Cursor:    defaultCursor,
@@ -141,6 +153,7 @@ var themes = map[string]theme{
 		Null:      defaultNull,
 		Boolean:   fg("5"),
 		Number:    fg("6"),
+		Size:      defaultSize,
 	},
 	"3": {
 		Cursor:    defaultCursor,
@@ -153,6 +166,7 @@ var themes = map[string]theme{
 		Null:      defaultNull,
 		Boolean:   fg("1"),
 		Number:    fg("14"),
+		Size:      defaultSize,
 	},
 	"4": {
 		Cursor:    defaultCursor,
@@ -165,6 +179,7 @@ var themes = map[string]theme{
 		Null:      defaultNull,
 		Boolean:   fg("#F15BB5"),
 		Number:    fg("#9B5DE5"),
+		Size:      defaultSize,
 	},
 	"5": {
 		Cursor:    defaultCursor,
@@ -177,6 +192,7 @@ var themes = map[string]theme{
 		Null:      defaultNull,
 		Boolean:   fg("#ee964b"),
 		Number:    fg("#ee964b"),
+		Size:      defaultSize,
 	},
 	"6": {
 		Cursor:    defaultCursor,
@@ -189,6 +205,7 @@ var themes = map[string]theme{
 		Null:      defaultNull,
 		Boolean:   fg("#FF6B6B"),
 		Number:    fg("#FFD93D"),
+		Size:      defaultSize,
 	},
 	"7": {
 		Cursor:    defaultCursor,
@@ -201,6 +218,7 @@ var themes = map[string]theme{
 		Null:      defaultNull,
 		Boolean:   boldFg("201"),
 		Number:    boldFg("201"),
+		Size:      defaultSize,
 	},
 	"8": {
 		Cursor:    defaultCursor,
@@ -213,6 +231,7 @@ var themes = map[string]theme{
 		Null:      defaultNull,
 		Boolean:   fg("50"),
 		Number:    fg("123"),
+		Size:      defaultSize,
 	},
 	"🔵": {
 		Cursor: toColor(lipgloss.NewStyle().
@@ -228,6 +247,7 @@ var themes = map[string]theme{
 		Null:      noColor,
 		Boolean:   noColor,
 		Number:    noColor,
+		Size:      defaultSize,
 	},
 	"🥝": {
 		Cursor:    defaultCursor,
@@ -240,6 +260,7 @@ var themes = map[string]theme{
 		Null:      fg("230"),
 		Boolean:   fg("226"),
 		Number:    fg("226"),
+		Size:      defaultSize,
 	},
 }
 


### PR DESCRIPTION
This is my attempt to add requested functionality. Few notes:

1. Disabled by default, can be enabled by setting `FX_SHOWSIZES` environment variable to a truthy value(`true`, `on`, `1`, `yes`, case does not matter).
2. Size indicator is formatted as `/* 123 */` -- to avoid confusing with actual values (e.g. `[ 123 ]` could be read as array with single numeric element)
3. Theme has separate color for size indicator, currently in all themes it is the same color which was used for `...`
4. For arrays, it replaces `...` with size indicator.
5. For objects, it replaces first key and `...` with size indicator (notation like `{"name":/* 123 */` would be very confusing).

closes #278