### PR TITLE
Append newline to autocomplete input if it's missing (fixes #303)

### DIFF
--- a/internal/complete/complete.go
+++ b/internal/complete/complete.go
@@ -139,10 +139,8 @@ func doComplete(compLine string, compWord string) {
 			return
 		}
 
-		// Append newline if it's missing. (https://github.com/antonmedv/fx/issues/303)
-		if input[len(input)-1] != '\n' {
-			input = append(input, '\n')
-		}
+		// Append newline to make sure that input is valid.
+		input = append(input, '\n')
 
 		// If input is bigger than 100MB, skip completion.
 		if len(input) > 100*1024*1024 {

--- a/internal/complete/complete.go
+++ b/internal/complete/complete.go
@@ -139,6 +139,11 @@ func doComplete(compLine string, compWord string) {
 			return
 		}
 
+		// Append newline if it's missing. (https://github.com/antonmedv/fx/issues/303)
+		if input[len(input)-1] != '\n' {
+			input = append(input, '\n')
+		}
+
 		// If input is bigger than 100MB, skip completion.
 		if len(input) > 100*1024*1024 {
 			return

--- a/internal/complete/complete.go
+++ b/internal/complete/complete.go
@@ -139,7 +139,6 @@ func doComplete(compLine string, compWord string) {
 			return
 		}
 
-		// Append newline to make sure that input is valid.
 		input = append(input, '\n')
 
 		// If input is bigger than 100MB, skip completion.


### PR DESCRIPTION
This fixes #303 by appending a newline to the autocomplete file input when it is missing.
The fix is tested and seems to work.