### PR TITLE
Feat: Open external editor on V

### DIFF
--- a/keymap.go
+++ b/keymap.go
@@ -36,6 +36,7 @@ type KeyMap struct {
 	GoBack              key.Binding
 	GoForward           key.Binding
 	Dig                 key.Binding
+	ExtEditor           key.Binding
 }
 
 var keyMap KeyMap
@@ -173,6 +174,10 @@ func init() {
 		Dig: key.NewBinding(
 			key.WithKeys("."),
 			key.WithHelp("", "dig"),
+		),
+		ExtEditor: key.NewBinding(
+			key.WithKeys("v"),
+			key.WithHelp("", "open in external editor"),
 		),
 	}
 }


### PR DESCRIPTION
### **Summary**
This PR introduces functionality that allows users to open their **configured `$EDITOR`** when in **interactive mode**, triggered by pressing the `V` key.

### **Changes**
- Adds a keyboard shortcut (`V`) to invoke the external editor.
- Uses `$EDITOR` environment variable to determine the preferred editor.

### **Usage**
1. Start fx in interactive mode e.g. `fx ./testdata/blog.json`
2. Press `V` → Opens the file in `$EDITOR`.
3. Make changes and save.

### **Additional Notes**
- If `$EDITOR` is not set, nothing happens