### PR TITLE
Center line on select node

### DIFF
--- a/main.go
+++ b/main.go
@@ -1214,6 +1214,7 @@ func (m *model) selectNode(n *Node) {
 		m.cursor = 0
 		m.head = n
 		m.scrollIntoView()
+		m.centerLine()
 	}
 	parent := n.Parent
 	for parent != nil {

--- a/view.go
+++ b/view.go
@@ -208,3 +208,15 @@ func (m *model) View() string {
 
 	return string(screen)
 }
+
+func (m *model) centerLine() {
+	middle := m.visibleLines() / 2
+
+	for range middle {
+		m.up()
+	}
+
+	for range middle {
+		m.down()
+	}
+}


### PR DESCRIPTION
When selecting node, center line in the middle of the screen if node is not inside the view