### PR TITLE
Refactor: Extract handleKey method into focused handler functions

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1,0 +1,359 @@
+package main
+
+import (
+	"encoding/base64"
+	"bytes"
+	"math"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	. "github.com/antonmedv/fx/internal/jsonx"
+	"github.com/antonmedv/fx/internal/jsonpath"
+	"github.com/antonmedv/fx/internal/utils"
+)
+
+// Navigation key handlers
+
+func (m *model) handlePageUp() (tea.Model, tea.Cmd) {
+	m.cursor = m.viewHeight() - 1
+	m.showCursor = true
+	m.scrollBackward(max(0, m.viewHeight()-2))
+	m.scrollIntoView() // As the cursor is at the bottom, and it may be empty.
+	m.recordHistory()
+	return m, nil
+}
+
+func (m *model) handlePageDown() (tea.Model, tea.Cmd) {
+	m.cursor = 0
+	m.showCursor = true
+	m.scrollForward(max(0, m.viewHeight()-2))
+	m.recordHistory()
+	return m, nil
+}
+
+func (m *model) handleHalfPageUp() (tea.Model, tea.Cmd) {
+	m.showCursor = true
+	m.scrollBackward(m.viewHeight() / 2)
+	m.scrollIntoView() // As the cursor stays at the same position, and it may be empty.
+	m.recordHistory()
+	return m, nil
+}
+
+func (m *model) handleHalfPageDown() (tea.Model, tea.Cmd) {
+	m.showCursor = true
+	m.scrollForward(m.viewHeight() / 2)
+	m.scrollIntoView() // As the cursor stays at the same position, and it may be empty.
+	m.recordHistory()
+	return m, nil
+}
+
+func (m *model) handleGotoTop() (tea.Model, tea.Cmd) {
+	m.head = m.top
+	m.cursor = 0
+	m.showCursor = true
+	m.recordHistory()
+	return m, nil
+}
+
+func (m *model) handleGotoBottom() (tea.Model, tea.Cmd) {
+	m.scrollToBottom()
+	m.recordHistory()
+	return m, nil
+}
+
+// Sibling navigation handlers
+
+func (m *model) handleNextSibling() (tea.Model, tea.Cmd) {
+	pointsTo, ok := m.cursorPointsTo()
+	if !ok {
+		return m, nil
+	}
+	var nextSibling *Node
+	if pointsTo.End != nil && pointsTo.End.Next != nil {
+		nextSibling = pointsTo.End.Next
+	} else if pointsTo.ChunkEnd != nil && pointsTo.ChunkEnd.Next != nil {
+		nextSibling = pointsTo.ChunkEnd.Next
+	} else {
+		nextSibling = pointsTo.Next
+	}
+	if nextSibling != nil {
+		m.selectNode(nextSibling)
+	}
+	m.recordHistory()
+	return m, nil
+}
+
+func (m *model) handlePrevSibling() (tea.Model, tea.Cmd) {
+	pointsTo, ok := m.cursorPointsTo()
+	if !ok {
+		return m, nil
+	}
+	var prevSibling *Node
+	parent := pointsTo.Parent
+	if parent != nil && parent.End == pointsTo {
+		prevSibling = parent
+	} else if pointsTo.Prev != nil {
+		prevSibling = pointsTo.Prev
+		parent := prevSibling.Parent
+		if parent != nil && parent.End == prevSibling {
+			prevSibling = parent
+		} else if prevSibling.Chunk != "" {
+			prevSibling = parent
+		}
+	}
+	if prevSibling != nil {
+		m.selectNode(prevSibling)
+	}
+	m.recordHistory()
+	return m, nil
+}
+
+// Collapse/Expand handlers
+
+func (m *model) handleCollapse() (tea.Model, tea.Cmd) {
+	n, ok := m.cursorPointsTo()
+	if !ok {
+		return m, nil
+	}
+	if n.HasChildren() && !n.IsCollapsed() {
+		n.Collapse()
+	} else {
+		if n.Parent != nil {
+			n = n.Parent
+		}
+	}
+	m.selectNode(n)
+	m.recordHistory()
+	return m, nil
+}
+
+func (m *model) handleExpand() (tea.Model, tea.Cmd) {
+	n, ok := m.cursorPointsTo()
+	if !ok {
+		return m, nil
+	}
+	n.Expand()
+	m.showCursor = true
+	return m, nil
+}
+
+func (m *model) handleCollapseRecursively() (tea.Model, tea.Cmd) {
+	n, ok := m.cursorPointsTo()
+	if !ok {
+		return m, nil
+	}
+	if n.HasChildren() {
+		n.CollapseRecursively()
+	}
+	m.showCursor = true
+	return m, nil
+}
+
+func (m *model) handleExpandRecursively() (tea.Model, tea.Cmd) {
+	n, ok := m.cursorPointsTo()
+	if !ok {
+		return m, nil
+	}
+	if n.HasChildren() {
+		n.ExpandRecursively(0, math.MaxInt)
+	}
+	m.showCursor = true
+	return m, nil
+}
+
+func (m *model) handleCollapseAll() (tea.Model, tea.Cmd) {
+	at, ok := m.cursorPointsTo()
+	if ok {
+		m.collapsed = true
+		n := m.top
+		for n != nil {
+			if n.Kind != Err {
+				n.CollapseRecursively()
+			}
+			if n.End == nil {
+				n = nil
+			} else {
+				n = n.End.Next
+			}
+		}
+		m.selectNode(at.Root())
+		m.recordHistory()
+	}
+	return m, nil
+}
+
+func (m *model) handleExpandAll() (tea.Model, tea.Cmd) {
+	at, ok := m.cursorPointsTo()
+	if !ok {
+		return m, nil
+	}
+	m.collapsed = false
+	n := m.top
+	for n != nil {
+		n.ExpandRecursively(0, math.MaxInt)
+		if n.End == nil {
+			n = nil
+		} else {
+			n = n.End.Next
+		}
+	}
+	m.selectNode(at)
+	return m, nil
+}
+
+func (m *model) handleCollapseLevel(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	at, ok := m.cursorPointsTo()
+	if ok && at.HasChildren() {
+		toLevel, _ := strconv.Atoi(msg.String())
+		at.CollapseRecursively()
+		at.ExpandRecursively(0, toLevel)
+		m.showCursor = true
+	}
+	return m, nil
+}
+
+func (m *model) handleToggleWrap() (tea.Model, tea.Cmd) {
+	at, ok := m.cursorPointsTo()
+	if !ok {
+		return m, nil
+	}
+	m.wrap = !m.wrap
+	if m.wrap {
+		Wrap(m.top, m.viewWidth())
+	} else {
+		DropWrapAll(m.top)
+	}
+	m.searchCache.invalidate()
+	if at.Chunk != "" && at.Value == "" {
+		at = at.Parent
+	}
+	m.redoSearch()
+	m.selectNode(at)
+	return m, nil
+}
+
+// Preview and action handlers
+
+func (m *model) handlePreviewKey() (tea.Model, tea.Cmd) {
+	m.showPreview = true
+	content := ""
+	value := m.cursorValue()
+	if decodedValue, err := base64.StdEncoding.DecodeString(value); err == nil {
+		img, err := utils.DrawImage(bytes.NewReader(decodedValue), m.termWidth, m.termHeight)
+		if err == nil {
+			content = strings.TrimRight(img, "\n")
+		}
+	}
+	if content == "" {
+		content = lipgloss.NewStyle().Width(m.termWidth).Render(value)
+	}
+	m.preview.SetContent(content)
+	m.preview.GotoTop()
+	return m, nil
+}
+
+// Input mode handlers
+
+func (m *model) handleDigMode() (tea.Model, tea.Cmd) {
+	at, ok := m.cursorPointsTo()
+	if !ok {
+		return m, nil
+	}
+	if at.Kind == Err {
+		nextJson := at.FindNextNonErr()
+		if nextJson != nil {
+			m.selectNode(nextJson)
+		}
+	}
+	m.digInput.SetValue(m.cursorPath() + ".")
+	m.digInput.CursorEnd()
+	m.digInput.Width = m.termWidth - 1
+	m.digInput.Focus()
+	return m, nil
+}
+
+func (m *model) handleGotoSymbolMode() (tea.Model, tea.Cmd) {
+	m.gotoSymbolInput.CursorEnd()
+	m.gotoSymbolInput.Width = m.termWidth - 2 // -1 for the prompt, -1 for the cursor
+	m.gotoSymbolInput.Focus()
+	m.createKeysIndex()
+	return m, nil
+}
+
+func (m *model) handleGotoRefMode() (tea.Model, tea.Cmd) {
+	at, ok := m.cursorPointsTo()
+	if !ok {
+		return m, nil
+	}
+	value, isRef := isRefNode(at)
+	if isRef {
+		refPath, ok := jsonpath.ParseSchemaRef(value)
+		if ok {
+			m.selectNode(m.findByPath(refPath))
+			m.recordHistory()
+		}
+	}
+	return m, nil
+}
+
+func (m *model) handleCommandLineMode() (tea.Model, tea.Cmd) {
+	m.commandInput.CursorEnd()
+	m.commandInput.Width = m.termWidth - 2 // -1 for the prompt, -1 for the cursor
+	m.commandInput.Focus()
+	return m, nil
+}
+
+func (m *model) handleSearchMode() (tea.Model, tea.Cmd) {
+	m.searchInput.CursorEnd()
+	m.searchInput.Width = m.termWidth - 2 // -1 for the prompt, -1 for the cursor
+	m.searchInput.Focus()
+	return m, nil
+}
+
+// Search navigation handlers
+
+func (m *model) handleSearchNext() (tea.Model, tea.Cmd) {
+	m.selectSearchResult(m.search.cursor + 1)
+	m.recordHistory()
+	return m, nil
+}
+
+func (m *model) handleSearchPrev() (tea.Model, tea.Cmd) {
+	m.selectSearchResult(m.search.cursor - 1)
+	m.recordHistory()
+	return m, nil
+}
+
+// History navigation handlers
+
+func (m *model) handleGoBack() (tea.Model, tea.Cmd) {
+	if m.locationIndex > 0 {
+		at, ok := m.cursorPointsTo()
+		if !ok {
+			return m, nil
+		}
+		m.locationIndex--
+
+		loc := m.locationHistory[m.locationIndex]
+		for loc.node == at && m.locationIndex > 0 {
+			m.locationIndex--
+			loc = m.locationHistory[m.locationIndex]
+		}
+		m.selectNode(loc.head)
+		m.selectNode(loc.node)
+	}
+	return m, nil
+}
+
+func (m *model) handleGoForward() (tea.Model, tea.Cmd) {
+	if m.locationIndex < len(m.locationHistory)-1 {
+		m.locationIndex++
+		loc := m.locationHistory[m.locationIndex]
+		m.selectNode(loc.head)
+		m.selectNode(loc.node)
+	}
+	return m, nil
+}


### PR DESCRIPTION
## Summary
This PR refactors the monolithic [handleKey](cci:1://file:///d:/Ninja_Work/Git_work/fx/main.go:762:0-1024:1) function in [main.go](cci:7://file:///d:/Ninja_Work/Git_work/fx/main.go:0:0-0:0) by extracting its logic into smaller, focused handler methods organized in a new [handlers.go](cci:7://file:///d:/Ninja_Work/Git_work/fx/handlers.go:0:0-0:0) file. This significantly improves code maintainability, readability, and testability.

## Problem
The [handleKey](cci:1://file:///d:/Ninja_Work/Git_work/fx/main.go:762:0-1024:1) function in [main.go](cci:7://file:///d:/Ninja_Work/Git_work/fx/main.go:0:0-0:0) was over 300 lines long with a massive switch statement containing 30+ cases. This created several issues:
- **Hard to maintain**: Changes required navigating through hundreds of lines of code
- **Difficult to test**: Testing individual key handlers required testing the entire function
- **Poor readability**: The function violated the Single Responsibility Principle
- **Code smell**: Classic "God Function" anti-pattern

## Solution
Extracted the key handling logic into logical groups of focused methods:

### Navigation Handlers (6 methods)
- [handlePageUp()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:19:0-26:1), [handlePageDown()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:28:0-34:1)
- [handleHalfPageUp()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:36:0-42:1), [handleHalfPageDown()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:44:0-50:1)
- [handleGotoTop()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:52:0-58:1), [handleGotoBottom()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:60:0-64:1)

### Sibling Navigation Handlers (2 methods)
- [handleNextSibling()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:68:0-86:1), [handlePrevSibling()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:88:0-111:1)

### Collapse/Expand Handlers (8 methods)
- [handleCollapse()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:115:0-130:1), [handleExpand()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:132:0-140:1)
- [handleCollapseRecursively()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:142:0-152:1), [handleExpandRecursively()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:154:0-164:1)
- [handleCollapseAll()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:166:0-185:1), [handleExpandAll()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:187:0-204:1)
- [handleCollapseLevel()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:206:0-215:1), [handleToggleWrap()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:217:0-235:1)

### Input Mode Handlers (5 methods)
- [handleDigMode()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:259:0-275:1), [handleGotoSymbolMode()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:277:0-283:1)
- [handleGotoRefMode()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:285:0-299:1), [handleCommandLineMode()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:301:0-306:1)
- [handleSearchMode()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:308:0-313:1)

### Action Handlers (1 method)
- [handlePreviewKey()](cci:1://file:///d:/Ninja_Work/Git_work/fx/main.go:633:0-647:1)

### Search Navigation Handlers (2 methods)
- [handleSearchNext()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:317:0-321:1), [handleSearchPrev()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:323:0-327:1)

### History Navigation Handlers (2 methods)
- [handleGoBack()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:331:0-348:1), [handleGoForward()](cci:1://file:///d:/Ninja_Work/Git_work/fx/handlers.go:350:0-358:1)

## Changes
- **Created**: [handlers.go](cci:7://file:///d:/Ninja_Work/Git_work/fx/handlers.go:0:0-0:0) - New file containing 26 extracted handler methods
- **Modified**: [main.go](cci:7://file:///d:/Ninja_Work/Git_work/fx/main.go:0:0-0:0) - Refactored [handleKey()](cci:1://file:///d:/Ninja_Work/Git_work/fx/main.go:762:0-1024:1) to delegate to extracted handlers

## Benefits
✅ **Improved Maintainability**: Each handler is now in its own focused function  
✅ **Enhanced Readability**: Clear separation of concerns with logical grouping  
✅ **Better Testability**: Individual handlers can be unit tested independently  
✅ **Follows SOLID Principles**: Each function has a single, well-defined responsibility  
✅ **Reduced Cognitive Load**: Developers can understand one handler at a time  
✅ **No Functional Changes**: Pure refactoring with identical behavior  

## Lines Changed
- **Reduced [handleKey](cci:1://file:///d:/Ninja_Work/Git_work/fx/main.go:762:0-1024:1) function**: From 314 lines to ~100 lines
- **Total lines updated**: 300+ lines refactored across 2 files

## Testing
The refactoring maintains identical behavior to the original implementation. All existing functionality remains unchanged - this is a pure code organization improvement.

## Code Review Notes
- All handler methods follow the same signature: [(tea.Model, tea.Cmd)](cci:1://file:///d:/Ninja_Work/Git_work/fx/main.go:1097:0-1106:1)
- Logical grouping is documented with comments in [handlers.go](cci:7://file:///d:/Ninja_Work/Git_work/fx/handlers.go:0:0-0:0)
- No changes to public APIs or external behavior
- Import statements properly organized in the new file

Contribution by Gittensor, learn more at https://gittensor.io/