### PR TITLE
fix: antonmedv/fx Docker image cannot run fx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -o fx .
+RUN CGO_ENABLED=0 go build -o fx .
 
 FROM alpine
 


### PR DESCRIPTION
Fixes #385

## Changes
- Add CGO_ENABLED=0 to Dockerfile build command for Alpine compatibility