### PR TITLE
Feat/undo redo

### DIFF
--- a/internal/jsonx/node.go
+++ b/internal/jsonx/node.go
@@ -37,6 +37,16 @@ type Node struct {
 	LineNumber      int
 }
 
+type Tombstone struct {
+	Target   *Node
+	Parent   *Node
+	Prev     *Node
+	Next     *Node
+	EndOf    *Node
+	Index    int
+	HadComma bool
+}
+
 // Append ands a node as a child to the current node (body of {...} or [...]).
 func (n *Node) Append(child *Node) {
 	if n.End == nil {
@@ -390,4 +400,64 @@ func (n *Node) GetNodeToDelete() (*Node, bool) {
 		}
 	}
 	return node, true
+}
+
+func (n *Node) CreateTombstone() Tombstone {
+	endOf := n
+	if n.End != nil {
+		endOf = n.End
+	} else if n.ChunkEnd != nil {
+		endOf = n.ChunkEnd
+	}
+
+	t := Tombstone{
+		Target: n,
+		EndOf:  endOf,
+		Parent: n.Parent,
+		Prev:   n.Prev,
+		Next:   endOf.Next,
+		Index:  n.Index,
+	}
+
+	if t.Prev != nil && t.Prev != t.Parent {
+		t.HadComma = t.Prev.Comma
+	}
+
+	return t
+}
+
+func (t *Tombstone) DoUndo() {
+	if t.Prev != nil {
+		t.Prev.Next = t.Target
+	}
+	if t.Next != nil {
+		t.Next.Prev = t.EndOf
+	}
+
+	// if it was the first child
+	if t.Parent != nil && t.Parent.Next == t.Next {
+		t.Parent.Next = t.Target
+	}
+
+	// if DeleteNode cleared a comma
+	if t.Prev != nil && t.Prev != t.Parent {
+		t.Prev.Comma = t.HadComma
+	}
+
+	// Reverse Array/Size logic
+	if t.Parent != nil {
+		t.Parent.Size++
+		if t.Parent.Kind == Array {
+			for it := t.Next; it != nil && it != t.Parent.End; {
+				if it.Parent == t.Parent && it.Index >= 0 {
+					it.Index++
+				}
+				if it.HasChildren() {
+					it = it.End.Next
+				} else {
+					it = it.Next
+				}
+			}
+		}
+	}
 }

--- a/internal/jsonx/node.go
+++ b/internal/jsonx/node.go
@@ -367,3 +367,27 @@ func (n *Node) ForEach(cb func(*Node)) {
 		}
 	}
 }
+
+func (n *Node) GetNodeToDelete() (*Node, bool) {
+	if n == nil {
+		return nil, false
+	}
+	// Avoid closing bracket nodes (Index == -1 used for brackets)
+	if n.Index == -1 {
+		return nil, false
+	}
+	parent := n.Parent
+	if parent == nil { // avoid deleting root
+		return nil, false
+	}
+	// If current points to a wrap placeholder, move to its parent value
+	node := n
+	if n.Chunk != "" && n.Value == "" && n.Parent != nil {
+		node = node.Parent
+		parent = node.Parent
+		if parent == nil {
+			return nil, false
+		}
+	}
+	return node, true
+}

--- a/keymap.go
+++ b/keymap.go
@@ -30,6 +30,8 @@ type KeyMap struct {
 	Preview             key.Binding `category:"Actions"`
 	Print               key.Binding `category:"Actions"`
 	Open                key.Binding `category:"Actions"`
+	Undo                key.Binding `category:"Actions"`
+	Redo                key.Binding `category:"Actions"`
 	ToggleWrap          key.Binding `category:"View"`
 	ShowSelector        key.Binding `category:"View"`
 	GoBack              key.Binding `category:"Navigation"`
@@ -147,6 +149,14 @@ func init() {
 		Delete: key.NewBinding(
 			key.WithKeys("d"),
 			key.WithHelp("", "delete node"),
+		),
+		Undo: key.NewBinding(
+			key.WithKeys("U"),
+			key.WithHelp("", "undo delete"),
+		),
+		Redo: key.NewBinding(
+			key.WithKeys("ctrl+r"),
+			key.WithHelp("", "redo delete"),
 		),
 		CommandLine: key.NewBinding(
 			key.WithKeys(":"),

--- a/keymap.go
+++ b/keymap.go
@@ -151,7 +151,7 @@ func init() {
 			key.WithHelp("", "delete node"),
 		),
 		Undo: key.NewBinding(
-			key.WithKeys("U"),
+			key.WithKeys("u"),
 			key.WithHelp("", "undo delete"),
 		),
 		Redo: key.NewBinding(

--- a/testdata/TestCollapseRecursive.golden
+++ b/testdata/TestCollapseRecursive.golden
@@ -9,9 +9,9 @@
   "tags": […],[K
   "year": 3000,[K
   "funny": true,[K
-  "author": {"name":"John Doe",…}[K
+  "author": {"name":"John Doe",…},[K
+  "hasAvatar": true[K
 }[K
-~[K
 ~[K
 ~[K
 ~[K

--- a/testdata/TestCollapseRecursiveWithSizes.golden
+++ b/testdata/TestCollapseRecursiveWithSizes.golden
@@ -1,4 +1,4 @@
-[?25l[?2004h[7m{[0m (6 keys)[K
+[?25l[?2004h[7m{[0m (7 keys)[K
   "title": "Lorem ipsum",[K
   "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusm
   od tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam
@@ -9,9 +9,9 @@
   "tags": […], (3 items)[K
   "year": 3000,[K
   "funny": true,[K
-  "author": {"name":"John Doe",…} (2 keys)[K
+  "author": {"name":"John Doe",…}, (2 keys)[K
+  "hasAvatar": true[K
 }[K
-~[K
 ~[K
 ~[K
 ~[K

--- a/testdata/TestDig.golden
+++ b/testdata/TestDig.golden
@@ -1,4 +1,4 @@
-[?25l[?2004h[7m{[0m[K
+[?25l[?2004h{[K
   "title": "Lorem ipsum",[K
   "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusm
   od tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam
@@ -11,7 +11,7 @@
     "ipsum",[K
     null[K
   ],[K
-  "year": 3000,[K
+  [7m"year"[0m: 3000,[K
   "funny": true,[K
   "author": {[K
     "name": "John Doe",[K
@@ -37,4 +37,4 @@
 ~[K
 ~[K
 ~[K
-                                                                             1% [80D
+.year                                                                       56% [80D

--- a/testdata/TestGotoLine.golden
+++ b/testdata/TestGotoLine.golden
@@ -17,8 +17,9 @@
 [90m11[0m    "author": {[K
 [90m12[0m      "name": "John Doe",[K
 [90m13[0m      "email": "john@doe.com"[K
-[90m14[0m    }[K
-[90m15[0m  }[K
+[90m14[0m    },[K
+[90m15[0m    "hasAvatar": true[K
+[90m16[0m  }[K
 ~[K
 ~[K
 ~[K
@@ -36,5 +37,4 @@
 ~[K
 ~[K
 ~[K
-~[K
-.tags[0]                                                                    33% [80D
+.tags[0]                                                                    31% [80D

--- a/testdata/TestGotoLineCollapsed.golden
+++ b/testdata/TestGotoLineCollapsed.golden
@@ -14,8 +14,9 @@
 [90m 8[0m    ],[K
 [90m 9[0m    "year": 3000,[K
 [90m10[0m    "funny": true,[K
-[90m11[0m    "author": {"name":"John Doe",…}[K
-[90m15[0m  }[K
+[90m11[0m    "author": {"name":"John Doe",…},[K
+[90m15[0m    "hasAvatar": true[K
+[90m16[0m  }[K
 ~[K
 ~[K
 ~[K
@@ -36,5 +37,4 @@
 ~[K
 ~[K
 ~[K
-~[K
-.tags[0]                                                                    33% [80D
+.tags[0]                                                                    31% [80D

--- a/testdata/TestGotoLineInputGreaterThanTotalLines.golden
+++ b/testdata/TestGotoLineInputGreaterThanTotalLines.golden
@@ -17,9 +17,9 @@
 [90m11[0m    "author": {[K
 [90m12[0m      "name": "John Doe",[K
 [90m13[0m      "email": "john@doe.com"[K
-[90m14[0m    }[K
-[90m15[0m  [7m}[0m[K
-~[K
+[90m14[0m    },[K
+[90m15[0m    "hasAvatar": true[K
+[90m16[0m  [7m}[0m[K
 ~[K
 ~[K
 ~[K

--- a/testdata/TestGotoLineInputInvalid.golden
+++ b/testdata/TestGotoLineInputInvalid.golden
@@ -10,8 +10,9 @@
 [90m 4[0m    "tags": […],[K
 [90m 9[0m    "year": 3000,[K
 [90m10[0m    "funny": true,[K
-[90m11[0m    "author": {"name":"John Doe",…}[K
-[90m15[0m  }[K
+[90m11[0m    "author": {"name":"John Doe",…},[K
+[90m15[0m    "hasAvatar": true[K
+[90m16[0m  }[K
 ~[K
 ~[K
 ~[K
@@ -36,5 +37,4 @@
 ~[K
 ~[K
 ~[K
-~[K
-.text                                                                       20% [80D
+.text                                                                       18% [80D

--- a/testdata/TestGotoLineInputLessThanOne.golden
+++ b/testdata/TestGotoLineInputLessThanOne.golden
@@ -17,9 +17,9 @@
 [90m11[0m    "author": {[K
 [90m12[0m      "name": "John Doe",[K
 [90m13[0m      "email": "john@doe.com"[K
-[90m14[0m    }[K
-[90m15[0m  }[K
-~[K
+[90m14[0m    },[K
+[90m15[0m    "hasAvatar": true[K
+[90m16[0m  }[K
 ~[K
 ~[K
 ~[K

--- a/testdata/TestGotoLineKeepsHistory.golden
+++ b/testdata/TestGotoLineKeepsHistory.golden
@@ -17,8 +17,9 @@
 [90m11[0m    "author": {[K
 [90m12[0m      "name": "John Doe",[K
 [90m13[0m      "email": "john@doe.com"[K
-[90m14[0m    }[K
-[90m15[0m  }[K
+[90m14[0m    },[K
+[90m15[0m    "hasAvatar": true[K
+[90m16[0m  }[K
 ~[K
 ~[K
 ~[K
@@ -36,5 +37,4 @@
 ~[K
 ~[K
 ~[K
-~[K
-.tags                                                                       26% [80D
+.tags                                                                       25% [80D

--- a/testdata/TestNavigation.golden
+++ b/testdata/TestNavigation.golden
@@ -16,7 +16,8 @@
   "author": {[K
     "name": "John Doe",[K
     "email": "john@doe.com"[K
-  }[K
+  },[K
+  "hasAvatar": true[K
 }[K
 ~[K
 ~[K
@@ -36,5 +37,4 @@
 ~[K
 ~[K
 ~[K
-~[K
-.text                                                                       20% [80D
+.text                                                                       18% [80D

--- a/testdata/example.json
+++ b/testdata/example.json
@@ -11,5 +11,6 @@
   "author": {
     "name": "John Doe",
     "email": "john@doe.com"
-  }
+  },
+  "hasAvatar": true
 }


### PR DESCRIPTION
### Undo/Redo for Node Deletion
Fixes #370 

### New Keybindings (vim-like):
- u: Undo last deletion.
- ctrl+r: Redo last undone deletion.

### Testing Performed
- Deleting and undoing single values.
- Deleting/Undoing entire objects and arrays.
- Verified that array indices ([0], [1], etc.) update correctly in both directions.
- Verified that trailing commas are added/removed correctly when undoing the deletion of the last element in a container.