### PR TITLE
feat: Supports JSON string escaping

### DIFF
--- a/internal/jsonx/transform.go
+++ b/internal/jsonx/transform.go
@@ -1,0 +1,235 @@
+package jsonx
+
+import "strings"
+
+// ReplaceNode copies the structure of parsed into target, reusing the target
+// pointer while splicing parsed's children into the surrounding linked list.
+// It preserves the target's key/index/parent relationships and trailing comma.
+func ReplaceNode(target *Node, parsed *Node) {
+	if target == nil || parsed == nil {
+		return
+	}
+
+	comma := trailingComma(target)
+	offset := int(target.Depth) - int(parsed.Depth)
+
+	// Remove any wrapped chunks on the target so Next points to the next sibling.
+	target.dropChunks()
+
+	// Detach children/subtrees that may currently hang off the target.
+	s := target.Next
+	if target.HasChildren() && !target.IsCollapsed() {
+		if target.End != nil {
+			s = target.End.Next
+		}
+	}
+	target.Next = s
+	if s != nil {
+		s.Prev = target
+	}
+	if target.IsCollapsed() {
+		target.Collapsed = nil
+	}
+	target.End = nil
+	target.Size = parsed.Size
+
+	// Copy primitive fields from parsed.
+	target.Kind = parsed.Kind
+	target.Value = parsed.Value
+
+	target.Comma = false
+
+	if !parsed.HasChildren() {
+		// Primitive replacement.
+		target.End = nil
+		if target.Next != nil {
+			target.Next.Prev = target
+		}
+		target.Comma = comma
+		return
+	}
+
+	first := parsed.Next
+	last := parsed.End
+	if first == nil || last == nil {
+		// Safety: fall back to primitive replacement semantics.
+		target.Comma = comma
+		return
+	}
+
+	// Connect the new child chain after the target and before the old sibling.
+	after := target.Next
+	target.Next = first
+	first.Prev = target
+	last.Next = after
+	if after != nil {
+		after.Prev = last
+	}
+	target.End = last
+	parsed.Next = nil
+	parsed.End = nil
+
+	reassignParentDepth(first, last, target, offset)
+
+	last.Comma = comma
+}
+
+// ClearChildren removes all children from node and returns whether the
+// original subtree ended with a trailing comma.
+func ClearChildren(node *Node) bool {
+	if node == nil {
+		return false
+	}
+	comma := trailingComma(node)
+	if !node.HasChildren() {
+		node.Collapsed = nil
+		node.End = nil
+		node.Size = 0
+		return comma
+	}
+	if node.IsCollapsed() {
+		node.Collapsed = nil
+		node.End = nil
+		node.Size = 0
+		return comma
+	}
+	start := node.Next
+	end := node.End
+	if start == nil || end == nil {
+		node.End = nil
+		node.Size = 0
+		return comma
+	}
+	after := end.Next
+	node.Next = after
+	if after != nil {
+		after.Prev = node
+	}
+	node.End = nil
+	node.Size = 0
+	return comma
+}
+
+// SerializeNode returns the JSON string representation of node's subtree.
+func SerializeNode(node *Node) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Kind {
+	case Object:
+		if !node.HasChildren() {
+			return node.Value
+		}
+		builder := new(strings.Builder)
+		builder.WriteString("{")
+		writeObjectChildren(builder, node)
+		builder.WriteString("}")
+		return builder.String()
+	case Array:
+		if !node.HasChildren() {
+			return node.Value
+		}
+		builder := new(strings.Builder)
+		builder.WriteString("[")
+		writeArrayChildren(builder, node)
+		builder.WriteString("]")
+		return builder.String()
+	default:
+		if node.Value != "" {
+			return node.Value
+		}
+		return node.Chunk
+	}
+}
+
+func writeObjectChildren(builder *strings.Builder, parent *Node) {
+	first := true
+	for child := firstChild(parent); child != nil && child != parent.End; child = nextSibling(child) {
+		if child.IsWrap() {
+			continue
+		}
+		if !first {
+			builder.WriteString(",")
+		}
+		first = false
+		builder.WriteString(child.Key)
+		builder.WriteString(":")
+		builder.WriteString(SerializeNode(child))
+	}
+}
+
+func writeArrayChildren(builder *strings.Builder, parent *Node) {
+	first := true
+	for child := firstChild(parent); child != nil && child != parent.End; child = nextSibling(child) {
+		if child.IsWrap() {
+			continue
+		}
+		if !first {
+			builder.WriteString(",")
+		}
+		first = false
+		builder.WriteString(SerializeNode(child))
+	}
+}
+
+func firstChild(parent *Node) *Node {
+	if parent == nil || !parent.HasChildren() {
+		return nil
+	}
+	if parent.IsCollapsed() {
+		return parent.Collapsed
+	}
+	return parent.Next
+}
+
+func nextSibling(node *Node) *Node {
+	if node == nil {
+		return nil
+	}
+	if node.HasChildren() && node.End != nil {
+		return node.End.Next
+	}
+	if node.ChunkEnd != nil {
+		return node.ChunkEnd.Next
+	}
+	return node.Next
+}
+
+func reassignParentDepth(start *Node, end *Node, parent *Node, offset int) {
+	if start == nil {
+		return
+	}
+	for node := start; node != nil; {
+		node.Parent = parent
+		newDepth := int(node.Depth) + offset
+		if newDepth < 0 {
+			newDepth = 0
+		}
+		if newDepth > 255 {
+			newDepth = 255
+		}
+		node.Depth = uint8(newDepth)
+		var next *Node
+		if node.HasChildren() && node.End != nil {
+			childOffset := offset
+			reassignParentDepth(node.Next, node.End, node, childOffset)
+			next = node.End.Next
+		} else {
+			next = node.Next
+		}
+		if node == end {
+			break
+		}
+		node = next
+	}
+}
+
+func trailingComma(node *Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.HasChildren() && node.End != nil {
+		return node.End.Comma
+	}
+	return node.Comma
+}

--- a/internal/jsonx/transform_test.go
+++ b/internal/jsonx/transform_test.go
@@ -1,0 +1,58 @@
+package jsonx
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceNodeAndSerialize(t *testing.T) {
+	root, err := Parse([]byte(`{"args":"{\"requestId\":\"746089c3b583ebb2f58a687cdaf925a8\",\"content\":\"123\"}","cost":16}`))
+	require.NoError(t, err)
+	args := root.findChildByKey("args")
+	require.NotNil(t, args)
+	require.Equal(t, String, args.Kind)
+	require.True(t, args.Comma, "string node should keep trailing comma")
+
+	parsed, err := Parse([]byte(`{"requestId":"746089c3b583ebb2f58a687cdaf925a8","content":"123"}`))
+	require.NoError(t, err)
+
+	ReplaceNode(args, parsed)
+
+	require.Equal(t, Object, args.Kind)
+	require.True(t, args.HasChildren())
+	require.NotNil(t, args.End)
+	require.True(t, args.End.Comma, "closing bracket should inherit comma")
+
+	child := args.findChildByKey("requestId")
+	require.NotNil(t, child)
+	require.Equal(t, String, child.Kind)
+
+	next := args.End.Next
+	require.NotNil(t, next)
+	unquoted := strings.Trim(next.Key, "\"")
+	require.Equal(t, "cost", unquoted)
+
+	serialized := SerializeNode(args)
+	require.Equal(t, `{"requestId":"746089c3b583ebb2f58a687cdaf925a8","content":"123"}`, serialized)
+}
+
+func TestClearChildren(t *testing.T) {
+	root, err := Parse([]byte(`{"args":{"a":1,"b":2},"cost":16}`))
+	require.NoError(t, err)
+	args := root.findChildByKey("args")
+	require.NotNil(t, args)
+	require.Equal(t, Object, args.Kind)
+	require.True(t, args.HasChildren())
+	require.True(t, args.End.Comma)
+
+	comma := ClearChildren(args)
+	require.True(t, comma)
+	require.False(t, args.HasChildren())
+	require.Nil(t, args.End)
+	next := args.Next
+	require.NotNil(t, next)
+	unquoted := strings.Trim(next.Key, "\"")
+	require.Equal(t, "cost", unquoted)
+}

--- a/keymap.go
+++ b/keymap.go
@@ -30,6 +30,8 @@ type KeyMap struct {
 	Preview             key.Binding `category:"Actions"`
 	Print               key.Binding `category:"Actions"`
 	Open                key.Binding `category:"Actions"`
+	DecodeJSON          key.Binding `category:"Actions"`
+	EncodeJSON          key.Binding `category:"Actions"`
 	ToggleWrap          key.Binding `category:"View"`
 	ShowSelector        key.Binding `category:"View"`
 	GoBack              key.Binding `category:"Navigation"`
@@ -175,6 +177,14 @@ func init() {
 		Open: key.NewBinding(
 			key.WithKeys("v"),
 			key.WithHelp("", "open in editor"),
+		),
+		DecodeJSON: key.NewBinding(
+			key.WithKeys("r"),
+			key.WithHelp("r", "decode JSON string"),
+		),
+		EncodeJSON: key.NewBinding(
+			key.WithKeys("R"),
+			key.WithHelp("R", "encode value as string"),
 		),
 		GoBack: key.NewBinding(
 			key.WithKeys("["),

--- a/main.go
+++ b/main.go
@@ -911,6 +911,16 @@ func (m *model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, keyMap.Open):
 		return m, m.open()
 
+	case key.Matches(msg, keyMap.DecodeJSON):
+		if m.decodeJSONString() {
+			m.recordHistory()
+		}
+
+	case key.Matches(msg, keyMap.EncodeJSON):
+		if m.encodeJSONValue() {
+			m.recordHistory()
+		}
+
 	case key.Matches(msg, keyMap.GotoSymbol):
 		m.gotoSymbolInput.CursorEnd()
 		m.gotoSymbolInput.Width = m.termWidth - 2 // -1 for the prompt, -1 for the cursor
@@ -1365,6 +1375,62 @@ func (m *model) cursorKey() string {
 		return v
 	}
 	return strconv.Itoa(at.Index)
+}
+
+func (m *model) editableNode() (*Node, bool) {
+	node, ok := m.cursorPointsTo()
+	if !ok || node == nil {
+		return nil, false
+	}
+	if node.IsWrap() && node.Parent != nil {
+		node = node.Parent
+	}
+	return node, true
+}
+
+func (m *model) decodeJSONString() bool {
+	node, ok := m.editableNode()
+	if !ok || node.Kind != String {
+		return false
+	}
+	raw, err := utils.Unquote(node.Value)
+	if err != nil {
+		return false
+	}
+	if !json.Valid([]byte(raw)) {
+		return false
+	}
+	parsed, err := Parse([]byte(raw))
+	if err != nil {
+		return false
+	}
+	ReplaceNode(node, parsed)
+	Wrap(node, m.viewWidth())
+	m.redoSearch()
+	m.selectNode(node)
+	return true
+}
+
+func (m *model) encodeJSONValue() bool {
+	node, ok := m.editableNode()
+	if !ok || node.Kind == String {
+		return false
+	}
+	serialized := SerializeNode(node)
+	if serialized == "" {
+		return false
+	}
+	comma := ClearChildren(node)
+	node.Kind = String
+	node.Value = strconv.Quote(serialized)
+	node.Size = 0
+	node.Collapsed = nil
+	node.End = nil
+	node.Comma = comma
+	Wrap(node, m.viewWidth())
+	m.redoSearch()
+	m.selectNode(node)
+	return true
 }
 
 func (m *model) findByPath(path []any) *Node {

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -61,6 +62,38 @@ func prepare(t *testing.T, opts ...options) *teatest.TestModel {
 	return tm
 }
 
+func newTestModelFromJSON(t *testing.T, data string) *model {
+	head, err := jsonx.Parse([]byte(data))
+	require.NoError(t, err)
+
+	m := &model{
+		top:          head,
+		head:         head,
+		bottom:       head,
+		totalLines:   head.Bottom().LineNumber,
+		eof:          true,
+		wrap:         true,
+		showCursor:   true,
+		searchInput:  textinput.New(),
+		search:       newSearch(),
+		commandInput: textinput.New(),
+	}
+	return m
+}
+
+func findChildByKey(n *jsonx.Node, key string) *jsonx.Node {
+	if n == nil {
+		return nil
+	}
+	keys, nodes := n.Children()
+	for i, k := range keys {
+		if k == key {
+			return nodes[i]
+		}
+	}
+	return nil
+}
+
 func read(t *testing.T, tm *teatest.TestModel) []byte {
 	var out []byte
 	teatest.WaitFor(t,
@@ -114,4 +147,30 @@ func TestCollapseRecursiveWithSizes(t *testing.T) {
 
 	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
 	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
+}
+
+func TestDecodeEncodeJSONNode(t *testing.T) {
+	m := newTestModelFromJSON(t, `{"args":"{\"requestId\":\"id\",\"content\":\"123\"}","cost":16}`)
+	args := findChildByKey(m.top, "args")
+	require.NotNil(t, args)
+	m.selectNode(args)
+	require.True(t, m.decodeJSONString())
+	require.Equal(t, jsonx.Object, args.Kind)
+	require.True(t, args.HasChildren())
+	require.NotNil(t, args.End)
+	require.Equal(t, args.Depth, args.End.Depth)
+	require.True(t, m.encodeJSONValue())
+	require.Equal(t, jsonx.String, args.Kind)
+	expected := `{"requestId":"id","content":"123"}`
+	require.Equal(t, strconv.Quote(expected), args.Value)
+}
+
+func TestDecodeJSONStringInvalidInputNoop(t *testing.T) {
+	m := newTestModelFromJSON(t, `{"clientIp":"10.156.175.39"}`)
+	ip := findChildByKey(m.top, "clientIp")
+	require.NotNil(t, ip)
+	m.selectNode(ip)
+	require.False(t, m.decodeJSONString())
+	require.Equal(t, jsonx.String, ip.Kind)
+	require.Equal(t, `"10.156.175.39"`, ip.Value)
 }


### PR DESCRIPTION
Supports JSON string escaping

New Actions:

- `r` decode json string
- `R` encode value as string

Example

input:
```json
{
  "clientIp": "127.0.0.1",
  "args": "{\"requestId\":\"746089c3b583ebb2f58a687cdaf925a8\",\"content\":\"123\"}",
  "ret": {
    "msg": "success"
  },
  "code": "OK",
  "cost": "16"
}
```

When the cursor is in the `args` field, pressing the `r` key will result is:
```json
{
  "clientIp": "127.0.0.1",
  "args": {
    "requestId": "746089c3b583ebb2f58a687cdaf925a8",
    "content": "123"
  },
  "ret": {
    "msg": "success"
  },
  "code": "OK",
  "cost": "16"
}
```
Pressing the `R` key again will restore the `args` field to string format.
