### PR TITLE
fix: skip home-based config paths when $HOME is not set

### DIFF
--- a/internal/engine/fxrc.go
+++ b/internal/engine/fxrc.go
@@ -18,16 +18,17 @@ func readFxrc() (string, error) {
 	paths := []string{filepath.Join(cwd, ".fxrc.js")}
 
 	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("get home: %w", err)
+	if err == nil {
+		paths = append(paths, filepath.Join(home, ".fxrc.js"))
 	}
-	paths = append(paths, filepath.Join(home, ".fxrc.js"))
 
 	xdgHome := os.Getenv("XDG_CONFIG_HOME")
-	if xdgHome == "" {
+	if xdgHome == "" && home != "" {
 		xdgHome = filepath.Join(home, ".config")
 	}
-	paths = append(paths, filepath.Join(xdgHome, "fx", ".fxrc.js"))
+	if xdgHome != "" {
+		paths = append(paths, filepath.Join(xdgHome, "fx", ".fxrc.js"))
+	}
 
 	xdgDirs := os.Getenv("XDG_CONFIG_DIRS")
 	if xdgDirs == "" {


### PR DESCRIPTION
When `$HOME` is not defined (e.g. running as a system user or in a minimal container), `os.UserHomeDir` returns an error. Previously `readFxrc` propagated this error, which caused a panic in `init()`:

```
panic: get home: $HOME is not defined
```

This change skips the home-based config paths (`~/.fxrc.js` and `~/.config/fx/.fxrc.js`) when the home directory is unavailable, instead of failing. The CWD-based `.fxrc.js` and `XDG_CONFIG_DIRS` paths still work, and `XDG_CONFIG_HOME` is honored if explicitly set.

Fixes #397