### PR TITLE
Decode JSON string escapes in preview and print

### DIFF
--- a/main.go
+++ b/main.go
@@ -1308,7 +1308,7 @@ func (m *model) cursorValue() string {
 	}
 
 	if at.Kind == String {
-		str, err := strconv.Unquote(at.Value)
+		str, err := utils.Unquote(at.Value)
 		if err == nil {
 			return str
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -84,6 +84,26 @@ func TestOutput(t *testing.T) {
 	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
 }
 
+// TestCursorValueDecodesJsonEscapesInWrappedArrayString verifies that preview
+// and print decode JSON string escapes even after the viewer wraps an array item.
+func TestCursorValueDecodesJsonEscapesInWrappedArrayString(t *testing.T) {
+	head, err := jsonx.Parse([]byte(`["before\ud83d\udd55\nsecond line after"]`))
+	require.NoError(t, err)
+
+	jsonx.Wrap(head, 12)
+	require.NotNil(t, head.Next)
+	require.NotNil(t, head.Next.ChunkEnd)
+
+	m := &model{
+		head:   head,
+		cursor: 1,
+	}
+	require.Equal(t, "before\U0001F555\nsecond line after", m.cursorValue())
+
+	m.cursor = 2
+	require.Equal(t, "before\U0001F555\nsecond line after", m.cursorValue())
+}
+
 func TestNavigation(t *testing.T) {
 	tm := prepare(t)
 


### PR DESCRIPTION
This fixes selected-string preview and print for valid JSON escapes that strconv.Unquote rejects, including surrogate pairs mixed with newlines, and adds a regression test for wrapped array string chunks.

Previously, if string had surrogate pairs, 'p' would show it with quotes.