### PR TITLE
build: update Go toolchain for CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/antonmedv/fx
 
 go 1.23.0
 
-toolchain go1.23.6
+toolchain go1.25.7
 
 require (
 	github.com/antonmedv/clipboard v1.0.1


### PR DESCRIPTION
# Motivation

Trivy reports the released Linux binary from `antonmedv/fx` `39.2.0` as a Go binary affected by stdlib [CVE-2025-68121](https://nvd.nist.gov/vuln/detail/cve-2025-68121) with CRITICAL severity.

The affected binary path from the downstream image scan is `mise/installs/fx/39.2.0/fx`. The released binary appears to have been built with Go `v1.23.6`; Trivy lists fixed Go stdlib versions as `1.24.13`, `1.25.7`, or `1.26.0-rc.3`.

# Summary of Changes

- Update the module toolchain directive from `go1.23.6` to stable fixed Go `go1.25.7`.
- Leave the module language version at `go 1.23.0`.
- Future release builds that run `scripts/build.mjs` with standard Go toolchain selection will build with the fixed Go toolchain.

# Dependencies/Special Considerations

None.