### PR TITLE
Fix file argument detection when stdin is /dev/null

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,10 +157,19 @@ func main() {
 	fd := os.Stdin.Fd()
 	stdinIsTty := isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
 
+	// Check if stdin is actually piped/redirected input, not just non-TTY
+	// Default to false (treat as file/code mode) if we can't stat stdin
+	stdinIsInput := false
+	if stat, err := os.Stdin.Stat(); err == nil {
+		// ModeCharDevice is 0 for regular files and pipes, meaning actual data
+		stdinIsInput = (stat.Mode() & os.ModeCharDevice) == 0
+	}
+
 	var fileName string
 	var src io.Reader
 
-	if stdinIsTty {
+	// Use file mode when stdin is TTY or when stdin is a non-input device (e.g., /dev/null in launch agents)
+	if stdinIsTty || !stdinIsInput {
 		if len(args) == 0 {
 			// $ fx
 			fmt.Println(usage())


### PR DESCRIPTION
When `fx` runs in non-TTY contexts (like macOS LaunchAgents) where stdin is redirected from `/dev/null`, it incorrectly assumes piped input. It then evaluates the first argument (a file path) as JavaScript, resulting in a `SyntaxError` (parsing `/tmp/package.json` as a RegExp literal `/tmp/` with flags `package.json`).

**Example:**
```
fx /tmp/package.json 'x.name = x.name.toUpperCase(), x' save
```

**Error:**
```
SyntaxError: Invalid flags supplied to RegExp constructor 'package' at 7:14
```

Previously, we relied solely on `isatty(stdin)`. This adds a device-type check using `os.ModeCharDevice`: character devices (TTY, `/dev/null`) route to file mode, while non-character devices (pipes, regular files) route to stdin-input mode.

Fixes #398