### PR TITLE
Fix issue reading files with Byte Order Mark

### DIFF
--- a/internal/jsonx/json.go
+++ b/internal/jsonx/json.go
@@ -35,9 +35,22 @@ func Parse(b []byte) (*Node, error) {
 }
 
 func NewJsonParser(rd io.Reader, strict bool) *JsonParser {
+	// Read up to the first 3 bytes to check for a BOM
+	header := make([]byte, 3)
+	n, _ := io.ReadFull(rd, header) // We ignore the error; if the file is < 3 bytes, n handles it
+
+	// Get stream to read
+	var finalReader io.Reader
+	if n == 3 && header[0] == '\xef' && header[1] == '\xbb' && header[2] == '\xbf' {
+		// It IS a BOM! throw the header away and proceed with the remaining stream
+		finalReader = rd
+	} else {
+		// Not a BOM - stitch the bytes we just read back onto the front of the stream
+		finalReader = io.MultiReader(bytes.NewReader(header[:n]), rd)
+	}
 	p := &JsonParser{
 		strict:         strict,
-		rd:             rd,
+		rd:             finalReader,
 		buf:            make([]byte, 4096),
 		lineNumber:     1,
 		realLineNumber: 1,

--- a/internal/jsonx/json.go
+++ b/internal/jsonx/json.go
@@ -39,18 +39,14 @@ func NewJsonParser(rd io.Reader, strict bool) *JsonParser {
 	header := make([]byte, 3)
 	n, _ := io.ReadFull(rd, header) // We ignore the error; if the file is < 3 bytes, n handles it
 
-	// Get stream to read
-	var finalReader io.Reader
-	if n == 3 && header[0] == '\xef' && header[1] == '\xbb' && header[2] == '\xbf' {
-		// It IS a BOM! throw the header away and proceed with the remaining stream
-		finalReader = rd
-	} else {
-		// Not a BOM - stitch the bytes we just read back onto the front of the stream
-		finalReader = io.MultiReader(bytes.NewReader(header[:n]), rd)
+	// Replace stream with stitched stream if BOM isn't detected
+	if n != 3 || header[0] != '\xef' || header[1] != '\xbb' || header[2] != '\xbf' {
+		rd = io.MultiReader(bytes.NewReader(header[:n]), rd)
 	}
+
 	p := &JsonParser{
 		strict:         strict,
-		rd:             finalReader,
+		rd:             rd,
 		buf:            make([]byte, 4096),
 		lineNumber:     1,
 		realLineNumber: 1,


### PR DESCRIPTION
This intercepts the io.Reader in the method to open a json file, reads the first 3 bytes, and if the first 3 bytes are the BOM in a file it skips over them. If they are not it returns a copy of the reader with the original 3 bytes inserted back in.

Would fix issue #418 

I am not primarily a go dev so please confirm this is a good approach with no performance implications or anything, it works fine on my machine in testing however.