### PR TITLE
Add llms.txt for LLM/agent-readable project summary

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,19 @@
+# fx
+
+> A terminal JSON viewer and processor. Interactively explore JSON/YAML/TOML in a TUI, or use fx non-interactively to query and transform data with a JavaScript-based expression syntax.
+
+## Getting Started
+
+- [Usage](https://github.com/antonmedv/fx#readme): `fx data.json`, `fx data.json .field`, `curl ... | fx` — basic invocation patterns, also shown in `fx --help`.
+- [Install](https://fx.wtf/install): Homebrew, Snap, Scoop, pacman, `go install`, npm, Deno, Docker, Nix, or the install script (`curl https://fx.wtf/install.sh | sh`).
+- [Full documentation](https://fx.wtf): Complete guides and reference beyond what's in this repo's README.
+
+## Usage
+
+- [CLI flags](https://github.com/antonmedv/fx/blob/master/help.go): `--raw`, `--slurp`, `--yaml`, `--toml`, `--strict`, `--no-inline`, `--comp <shell>` for completion, `--themes`, and more — see `fx --help` for the authoritative list.
+- [Key bindings](https://github.com/antonmedv/fx/blob/master/keymap.go): Navigation, Expand/Collapse, Search, Actions, and View bindings; press `?` inside fx for the live help screen.
+
+## Optional
+
+- [Related tools](https://github.com/antonmedv/fx#related): [walk](https://github.com/antonmedv/walk) (terminal file manager), [howto](https://github.com/antonmedv/howto) (terminal command LLM helper), [countdown](https://github.com/antonmedv/countdown).
+- [License](https://github.com/antonmedv/fx/blob/master/LICENSE): MIT.


### PR DESCRIPTION
This repo doesn't have an [`llms.txt`](https://llmstxt.org) file yet — a small, curated markdown index (title, one-line summary, and grouped links to the docs that matter) that AI coding agents can read to understand a project quickly, instead of having to crawl and guess.

fx's own README is intentionally minimal and defers almost everything to [fx.wtf](https://fx.wtf), which makes it a slightly different case than a repo with docs already in-tree: an agent working from the GitHub repo alone (no network access to the docs site, or just working faster from local files) currently has very little to go on beyond "see fx.wtf." This llms.txt pulls the flags and key bindings that already live in the binary itself (`help.go`, `keymap.go`) into a repo-local index, and links out to the hosted docs and install script for everything else — so the repo has *something* self-describing even without a live fetch of fx.wtf.

Content is derived from your existing README, the `usage()` string in `help.go`, the `KeyMap` struct in `keymap.go`, and the install commands published at fx.wtf/install — no new claims, just pointers. Given fx is one of the larger/more visible tools on this list, happy to adjust scope or trim sections if you'd rather this stay closer to the README's current minimalism. Validated against the [llms.txt spec](https://llmstxt.org) with [llms-txt-lint](https://github.com/abyworkings-coder/llms-txt-lint) (disclosure: a small validator tool I maintain — happy to drop that line from the PR if you'd rather not have it).

Totally understand if this isn't something you want to maintain — no worries either way, feel free to close.