### PR TITLE
Add FX_PREVIEW to transform strings in the preview pane

### DIFF
--- a/main.go
+++ b/main.go
@@ -905,6 +905,11 @@ func (m *model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 		if view == "" {
+			if transform := lookup([]string{"FX_PREVIEW"}, ""); transform != "" {
+				if out, err := previewTransform(transform, value); err == nil {
+					value = out
+				}
+			}
 			view = lipgloss.NewStyle().Width(m.termWidth).Render(value)
 		}
 		m.previewValue = value

--- a/preview_test.go
+++ b/preview_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+func TestPreviewTransform(t *testing.T) {
+	out, err := previewTransform("tr a-z A-Z", "hello world")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "HELLO WORLD" {
+		t.Errorf("got %q, want %q", out, "HELLO WORLD")
+	}
+}
+
+func TestPreviewTransformTrimsTrailingNewline(t *testing.T) {
+	// jq and most filters end their output with a newline; the preview pane
+	// shouldn't carry it.
+	out, err := previewTransform("cat", "line\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "line" {
+		t.Errorf("got %q, want %q", out, "line")
+	}
+}
+
+func TestPreviewTransformError(t *testing.T) {
+	if _, err := previewTransform("exit 1", "x"); err == nil {
+		t.Error("expected error from failing command")
+	}
+}
+
+// When FX_PREVIEW is unset the preview path never calls previewTransform, so
+// the value is shown verbatim.
+func TestPreviewNoTransformWhenUnset(t *testing.T) {
+	t.Setenv("FX_PREVIEW", "")
+	if got := lookup([]string{"FX_PREVIEW"}, ""); got != "" {
+		t.Errorf("expected empty transform, got %q", got)
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path"
 	"regexp"
 	"strconv"
@@ -25,6 +26,19 @@ func lookup(names []string, defaultEditor string) string {
 		}
 	}
 	return defaultEditor
+}
+
+// previewTransform pipes value through the shell command and returns its
+// stdout. Used by the preview action when FX_PREVIEW is set so nested JSON,
+// markdown, etc. inside a string can be rendered without leaving fx.
+func previewTransform(command, value string) (string, error) {
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Stdin = strings.NewReader(value)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(out), "\n"), nil
 }
 
 func open(filePath string, flagYaml, flagToml *bool) *os.File {


### PR DESCRIPTION
Closes #408. Lets you set `FX_PREVIEW` to a shell command that the preview action (<kbd>p</kbd>) pipes the selected string through, so nested JSON or markdown crammed into a string renders instead of showing as one flat line.

It's opt-in. With `FX_PREVIEW` unset the preview path is untouched, so default behavior is byte-for-byte the same. When it's set, the string is fed to `sh -c "$FX_PREVIEW"` on stdin and the command's stdout replaces what the pane shows, and you stay in fx (unlike <kbd>P</kbd>, which exits). Image previews still take priority; the transform only runs on the plain-string branch.

Some things I reach for:

```
FX_PREVIEW='jq .' fx data.json      # a string that's actually JSON
FX_PREVIEW='glow -' fx notes.json   # a markdown string
```

Kept it env-var shaped to match `FX_EDITOR` and the rest of the `FX_*` knobs rather than adding a flag. Trailing newline from the command output is trimmed so jq and friends don't leave a blank line in the pane. If the command fails it falls back to the untransformed string.

Tests in `preview_test.go` cover the transform running, the newline trim, a failing command, and the unset case being a no-op. `go build ./...`, `go test ./...` and `gofmt -l` are clean; `go vet` only flags the pre-existing unkeyed-struct warning in the completion code.

Docs live in the fx.wtf repo so I left those out of this PR, happy to send a follow-up there for the env var if you want it written up.
