### PR TITLE
docs: add link to a live browser demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ See full documentation at [fx.wtf](https://fx.wtf).
 - [walk](https://github.com/antonmedv/walk) – terminal file manager
 - [howto](https://github.com/antonmedv/howto) – terminal command LLM helper
 - [countdown](https://github.com/antonmedv/countdown) – terminal countdown timer
+- Online demo: <a href="https://build.demoshell.com/launch?snapshot=demoshell%2Ftui%3Afx"><img src="https://build.demoshell.com/v1/embed/badge.svg" alt="Live demo by Demoshell" align="absmiddle"></a>
 
 ## License
 


### PR DESCRIPTION
Adds a "Online demo" link to the README, pointing to fx running in the browser: https://gallery.demoshell.com/app/fx/

It's the actual fx binary inside an emulated Linux VM (WebAssembly). The VM is seeded with a few nested JSON files so interactive walking, filtering, and the reducer syntax can be tried directly. The image rebuilds automatically when a new release is published.

Disclosure: I run the service behind this (Demoshell). The demo and hosting are free for open-source projects (the badge carries a small attribution). 

The demo page also allows the maintainer to claim that VM if you'd like to support it. Otherwise I'll keep taking care of it. 