### PR TITLE
chore: add optional RepoRoad building

### DIFF
--- a/.reporoad.yml
+++ b/.reporoad.yml
@@ -1,0 +1,11 @@
+# Optional building on https://reporoad.org
+# After merging, submit this repository on the site to join.
+version: 1
+style: townhouse
+color: "#bb8753"
+roof: gable
+signText: fx
+garden: true
+support:
+  sponsor: false
+  helpWanted: false


### PR DESCRIPTION
Want a building on [RepoRoad](https://reporoad.org)? It’s a live lo-fi drive through open-source projects, represented as voxel buildings. This PR contains only the `.reporoad.yml` appearance settings—no code changes or dependencies. If you’re interested, merge it and submit your repository on the site to join.