### PR TITLE
Add --no-paging and FX_NO_PAGER for noninteractive output

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 See full documentation at [fx.wtf](https://fx.wtf).
 
+To pretty-print without opening the interactive viewer, use `fx --no-paging data.json`
+or `cat data.json | fx --no-paging`. Setting `FX_NO_PAGER` enables the same behavior:
+`cat data.json | FX_NO_PAGER=1 fx`. With no expression, this is equivalent to passing
+`.`; explicit expressions and input-format flags continue to work as usual.
+
 ## Related
 
 - [walk](https://github.com/antonmedv/walk) – terminal file manager

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCLIProcess(t *testing.T) {
+	if os.Getenv("FX_TEST_MAIN") != "1" {
+		return
+	}
+	for i, arg := range os.Args {
+		if arg == "--" {
+			os.Args = append([]string{"fx"}, os.Args[i+1:]...)
+			main()
+			os.Exit(0)
+		}
+	}
+	t.Fatal("missing CLI argument separator")
+}
+
+func TestNoPaging(t *testing.T) {
+	executable, err := os.Executable()
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		name  string
+		args  []string
+		env   []string
+		input string
+		file  bool
+		want  string
+		fail  bool
+	}{
+		{"flag stdin", []string{"--no-paging"}, nil, `{"a":1}`, false, "{\n  \"a\": 1\n}\n", false},
+		{"environment stdin", nil, []string{"FX_NO_PAGER=1"}, `{"a":1}`, false, "{\n  \"a\": 1\n}\n", false},
+		{"flag file", []string{"--no-paging"}, nil, `{"a":1}`, true, "{\n  \"a\": 1\n}\n", false},
+		{"environment file", nil, []string{"FX_NO_PAGER=1"}, `{"a":1}`, true, "{\n  \"a\": 1\n}\n", false},
+		{"transform", []string{".a"}, []string{"FX_NO_PAGER=1"}, `{"a":1}`, false, "1\n", false},
+		{"stream", []string{"--no-paging"}, nil, "1\n2", false, "1\n2\n", false},
+		{"raw", []string{"--no-paging", "--raw"}, nil, "hello\nworld", false, "hello\nworld\n", false},
+		{"yaml", []string{"--no-paging", "--yaml"}, nil, "a: 1", false, "{\n  \"a\": 1\n}\n", false},
+		{"slurp", []string{"--no-paging", "--slurp"}, nil, "1\n2", false, "[\n  1,\n  2\n]\n", false},
+		{"invalid input", []string{"--no-paging", "--strict"}, nil, "{", false, "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			args := append([]string{"-test.run=^TestCLIProcess$", "--"}, tc.args...)
+			if tc.file {
+				path := filepath.Join(t.TempDir(), "input.json")
+				require.NoError(t, os.WriteFile(path, []byte(tc.input), 0600))
+				args = append(args, path)
+			}
+			cmd := exec.CommandContext(ctx, executable, args...)
+			cmd.Dir = t.TempDir()
+			cmd.Env = append([]string{"FX_TEST_MAIN=1", "FX_THEME=0"}, tc.env...)
+			if !tc.file {
+				cmd.Stdin = strings.NewReader(tc.input)
+			}
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout, cmd.Stderr = &stdout, &stderr
+			err := cmd.Run()
+			require.NoError(t, ctx.Err(), "CLI did not exit")
+			if tc.fail {
+				require.Error(t, err)
+				require.NotEmpty(t, stderr.String())
+			} else {
+				require.NoError(t, err, stderr.String())
+				require.Empty(t, stderr.String())
+			}
+			require.Equal(t, tc.want, stdout.String())
+		})
+	}
+}

--- a/help.go
+++ b/help.go
@@ -33,7 +33,11 @@ func usage() string {
     --toml                parse input as TOML
     --strict              strict mode
     --no-inline           disable inlining in output
+    --no-paging            print to stdout without the interactive viewer
     --game-of-life        play the game of life
+
+  %v
+    FX_NO_PAGER            enable --no-paging when set
 
   %v
     https://fx.wtf
@@ -44,6 +48,7 @@ func usage() string {
 		title.Render("fx "+version),
 		title.Render("Usage"),
 		title.Render("Flags"),
+		title.Render("Environment"),
 		title.Render("More info"),
 		title.Render("Author"),
 	)

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ var (
 	flagComp     bool
 	flagStrict   bool
 	flagNoInline bool
+	flagNoPaging bool
 )
 
 var flags = []string{
@@ -54,6 +55,7 @@ var flags = []string{
 	"--toml",
 	"--strict",
 	"--no-inline",
+	"--no-paging",
 }
 
 func init() {
@@ -121,6 +123,8 @@ func main() {
 			flagStrict = true
 		case "--no-inline":
 			flagNoInline = true
+		case "--no-paging":
+			flagNoPaging = true
 		case "--game-of-life":
 			utils.GameOfLife()
 			return
@@ -217,6 +221,11 @@ func main() {
 		parser = NewLineParser(src)
 	} else {
 		parser = NewJsonParser(src, flagStrict)
+	}
+
+	_, noPager := os.LookupEnv("FX_NO_PAGER")
+	if (flagNoPaging || noPager) && len(args) == 0 {
+		args = []string{"."}
 	}
 
 	if len(args) > 0 || flagSlurp {


### PR DESCRIPTION
Fixes #421.

Add `--no-paging` and `FX_NO_PAGER` so files and piped input can be printed without opening the interactive viewer. With no expression, these select the existing `.` output path; explicit transforms, raw/YAML/TOML input, slurping, and parser error handling retain their existing behavior. The environment variable follows the presence-based convention of `FX_COLLAPSED` and `FX_NO_MOUSE`.

The flag is included in completion and help, with usage examples in the README. This reuses the normal expression parser, including its handling of HTTP-prefixed input.

Validation: ten subprocess CLI cases cover flag/environment activation, file/stdin input, transforms, streams, raw/YAML input, slurping, and invalid input. The new activation cases fail on the original code. `go test ./...`, `go test -race ./...`, `go vet ./...`, `go build`, and `cd npm && node test.js` pass locally on macOS with Go 1.27.1.

Implemented and locally validated with OpenAI Codex.
